### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ methods outputs should be exposed to other classes.
 <dependency>
     <groupId>io.github.suppierk</groupId>
     <artifactId>inject</artifactId>
-    <version>3.0.1</version>
+    <version>3.1.0</version>
 </dependency>
 ```
 
 - **Gradle** (_works for both Groovy and Kotlin_)
 
 ```groovy
-implementation("io.github.suppierk:inject:3.0.1")
+implementation("io.github.suppierk:inject:3.1.0")
 ```
 
 ## Hello, World!

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import java.nio.charset.StandardCharsets
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
 	// IDE
@@ -11,11 +12,15 @@ plugins {
 	// Publishing
 	id 'com.vanniktech.maven.publish' version '0.36.0'
 
+	// https://plugins.gradle.org/plugin/net.ltgt.errorprone
+	id 'net.ltgt.errorprone' version '5.1.0'
+
 	// Utility
 	id 'jacoco'
 	id 'info.solidsoft.pitest' version '1.19.0'
 	id 'com.diffplug.spotless' version '8.6.0'
 	id 'org.sonarqube' version '7.3.0.8198'
+	id 'me.champeau.jmh' version '0.7.3'
 }
 
 group = "$GROUP"
@@ -29,6 +34,15 @@ repositories {
 dependencies {
 	// https://mvnrepository.com/artifact/jakarta.inject/jakarta.inject-api
 	api group: 'jakarta.inject', name: 'jakarta.inject-api', version: jakartaVersion
+
+	// https://mvnrepository.com/artifact/org.jspecify/jspecify
+	api group: 'org.jspecify', name: 'jspecify', version: jspecifyVersion
+
+	// https://mvnrepository.com/artifact/com.google.errorprone/error_prone_core
+	errorprone group: 'com.google.errorprone', name: 'error_prone_core', version: errorProneVersion
+
+	// https://mvnrepository.com/artifact/com.uber.nullaway/nullaway
+	errorprone group: 'com.uber.nullaway', name: 'nullaway', version: nullAwayVersion
 
 	// https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter
 	testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: jUnitVersion
@@ -74,7 +88,7 @@ jacocoTestReport {
 // Enable Spotless code formatting rules
 spotless {
 	java {
-		target '**/src/*/java/**/*.java'
+		target fileTree(dir: projectDir, includes: ['src/*/java/**/*.java'])
 
 		// Aligns with Intellij IDEA default settings
 		toggleOffOn('@formatter:off', '@formatter:on')
@@ -83,7 +97,7 @@ spotless {
 	}
 
 	groovyGradle {
-		target '**/*.gradle'
+		target files('build.gradle', 'settings.gradle')
 
 		greclipse()
 	}
@@ -95,6 +109,19 @@ tasks.withType(Copy).configureEach {
 }
 
 tasks.withType(JavaCompile).configureEach {
+	options.errorprone {
+		disableAllChecks = true
+		check("NullAway", CheckSeverity.ERROR)
+		option("NullAway:AnnotatedPackages", "io.github.suppierk")
+	}
+
+	// Include to disable NullAway on test and benchmark code
+	if (name.toLowerCase().contains("test") || name.toLowerCase().contains("jmh")) {
+		options.errorprone {
+			disable("NullAway")
+		}
+	}
+
 	options.encoding = StandardCharsets.UTF_8.name()
 	dependsOn(spotlessJavaCheck)
 }
@@ -105,6 +132,25 @@ pitest {
 	outputFormats = ['HTML']
 	timestampedReports = false
 	junit5PluginVersion = '1.2.1'
+}
+
+jmh {
+	String jmhIncludes = findProperty('jmhIncludes')
+	if (jmhIncludes != null) {
+		includes = [jmhIncludes]
+	}
+
+	jvmArgsAppend = ['-Xmx2G']
+	benchmarkMode = ['avgt']
+	timeUnit = 'ns'
+
+	warmup = '1s'
+	warmupIterations = 5
+
+	timeOnIteration = '1s'
+	iterations = 20
+
+	profilers = ['jfr']
 }
 
 sonar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,8 @@
 # Dependencies
 jakartaVersion=2.0.1
+jspecifyVersion=1.0.0
+errorProneVersion=2.42.0
+nullAwayVersion=0.13.1
 jUnitVersion=5.13.0
 equalsVerifierVersion=4.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ SONATYPE_AUTOMATIC_RELEASE=true
 
 GROUP=io.github.suppierk
 POM_ARTIFACT_ID=inject
-VERSION_NAME=3.0.1
+VERSION_NAME=3.1.0
 
 POM_NAME=Simple Dependency Injector
 POM_DESCRIPTION=Java 11 compatible implementation of the JSR 330 dependency injection

--- a/src/jmh/java/io/github/suppierk/inject/InjectorBenchmark.java
+++ b/src/jmh/java/io/github/suppierk/inject/InjectorBenchmark.java
@@ -1,0 +1,2101 @@
+/*
+ * MIT License
+ *
+ * Copyright 2026 Roman Khlebnov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.suppierk.inject;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@SuppressWarnings("unused")
+public class InjectorBenchmark {
+  private static final Class<?>[] CHAIN_CLASSES = {
+    Chain00.class,
+    Chain01.class,
+    Chain02.class,
+    Chain03.class,
+    Chain04.class,
+    Chain05.class,
+    Chain06.class,
+    Chain07.class,
+    Chain08.class,
+    Chain09.class,
+    Chain10.class,
+    Chain11.class,
+    Chain12.class,
+    Chain13.class,
+    Chain14.class,
+    Chain15.class,
+    Chain16.class,
+    Chain17.class,
+    Chain18.class,
+    Chain19.class,
+    Chain20.class,
+    Chain21.class,
+    Chain22.class,
+    Chain23.class,
+    Chain24.class,
+    Chain25.class,
+    Chain26.class,
+    Chain27.class,
+    Chain28.class,
+    Chain29.class,
+    Chain30.class,
+    Chain31.class,
+    Chain32.class,
+    Chain33.class,
+    Chain34.class,
+    Chain35.class,
+    Chain36.class,
+    Chain37.class,
+    Chain38.class,
+    Chain39.class,
+    Chain40.class,
+    Chain41.class,
+    Chain42.class,
+    Chain43.class,
+    Chain44.class,
+    Chain45.class,
+    Chain46.class,
+    Chain47.class,
+    Chain48.class,
+    Chain49.class,
+    Chain50.class,
+    Chain51.class,
+    Chain52.class,
+    Chain53.class,
+    Chain54.class,
+    Chain55.class,
+    Chain56.class,
+    Chain57.class,
+    Chain58.class,
+    Chain59.class,
+    Chain60.class,
+    Chain61.class,
+    Chain62.class,
+    Chain63.class
+  };
+
+  private static final Class<?>[] SINGLETON_CHAIN_CLASSES = {
+    SingletonChain00.class,
+    SingletonChain01.class,
+    SingletonChain02.class,
+    SingletonChain03.class,
+    SingletonChain04.class,
+    SingletonChain05.class,
+    SingletonChain06.class,
+    SingletonChain07.class,
+    SingletonChain08.class,
+    SingletonChain09.class,
+    SingletonChain10.class,
+    SingletonChain11.class,
+    SingletonChain12.class,
+    SingletonChain13.class,
+    SingletonChain14.class,
+    SingletonChain15.class,
+    SingletonChain16.class,
+    SingletonChain17.class,
+    SingletonChain18.class,
+    SingletonChain19.class,
+    SingletonChain20.class,
+    SingletonChain21.class,
+    SingletonChain22.class,
+    SingletonChain23.class,
+    SingletonChain24.class,
+    SingletonChain25.class,
+    SingletonChain26.class,
+    SingletonChain27.class,
+    SingletonChain28.class,
+    SingletonChain29.class,
+    SingletonChain30.class,
+    SingletonChain31.class,
+    SingletonChain32.class,
+    SingletonChain33.class,
+    SingletonChain34.class,
+    SingletonChain35.class,
+    SingletonChain36.class,
+    SingletonChain37.class,
+    SingletonChain38.class,
+    SingletonChain39.class,
+    SingletonChain40.class,
+    SingletonChain41.class,
+    SingletonChain42.class,
+    SingletonChain43.class,
+    SingletonChain44.class,
+    SingletonChain45.class,
+    SingletonChain46.class,
+    SingletonChain47.class,
+    SingletonChain48.class,
+    SingletonChain49.class,
+    SingletonChain50.class,
+    SingletonChain51.class,
+    SingletonChain52.class,
+    SingletonChain53.class,
+    SingletonChain54.class,
+    SingletonChain55.class,
+    SingletonChain56.class,
+    SingletonChain57.class,
+    SingletonChain58.class,
+    SingletonChain59.class,
+    SingletonChain60.class,
+    SingletonChain61.class,
+    SingletonChain62.class,
+    SingletonChain63.class
+  };
+
+  private static final Class<?>[] PROVIDER_FACTORY_CLASSES = {
+    ProviderFactory00.class,
+    ProviderFactory01.class,
+    ProviderFactory02.class,
+    ProviderFactory03.class,
+    ProviderFactory04.class,
+    ProviderFactory05.class,
+    ProviderFactory06.class,
+    ProviderFactory07.class,
+    ProviderFactory08.class,
+    ProviderFactory09.class,
+    ProviderFactory10.class,
+    ProviderFactory11.class,
+    ProviderFactory12.class,
+    ProviderFactory13.class,
+    ProviderFactory14.class,
+    ProviderFactory15.class,
+    ProviderFactory16.class,
+    ProviderFactory17.class,
+    ProviderFactory18.class,
+    ProviderFactory19.class,
+    ProviderFactory20.class,
+    ProviderFactory21.class,
+    ProviderFactory22.class,
+    ProviderFactory23.class,
+    ProviderFactory24.class,
+    ProviderFactory25.class,
+    ProviderFactory26.class,
+    ProviderFactory27.class,
+    ProviderFactory28.class,
+    ProviderFactory29.class,
+    ProviderFactory30.class,
+    ProviderFactory31.class,
+    ProviderFactory32.class,
+    ProviderFactory33.class,
+    ProviderFactory34.class,
+    ProviderFactory35.class,
+    ProviderFactory36.class,
+    ProviderFactory37.class,
+    ProviderFactory38.class,
+    ProviderFactory39.class,
+    ProviderFactory40.class,
+    ProviderFactory41.class,
+    ProviderFactory42.class,
+    ProviderFactory43.class,
+    ProviderFactory44.class,
+    ProviderFactory45.class,
+    ProviderFactory46.class,
+    ProviderFactory47.class,
+    ProviderFactory48.class,
+    ProviderFactory49.class,
+    ProviderFactory50.class,
+    ProviderFactory51.class,
+    ProviderFactory52.class,
+    ProviderFactory53.class,
+    ProviderFactory54.class,
+    ProviderFactory55.class,
+    ProviderFactory56.class,
+    ProviderFactory57.class,
+    ProviderFactory58.class,
+    ProviderFactory59.class,
+    ProviderFactory60.class,
+    ProviderFactory61.class,
+    ProviderFactory62.class,
+    ProviderFactory63.class
+  };
+
+  private static final Class<?>[] PROVIDER_NODE_CLASSES = {
+    ProviderNode00.class,
+    ProviderNode01.class,
+    ProviderNode02.class,
+    ProviderNode03.class,
+    ProviderNode04.class,
+    ProviderNode05.class,
+    ProviderNode06.class,
+    ProviderNode07.class,
+    ProviderNode08.class,
+    ProviderNode09.class,
+    ProviderNode10.class,
+    ProviderNode11.class,
+    ProviderNode12.class,
+    ProviderNode13.class,
+    ProviderNode14.class,
+    ProviderNode15.class,
+    ProviderNode16.class,
+    ProviderNode17.class,
+    ProviderNode18.class,
+    ProviderNode19.class,
+    ProviderNode20.class,
+    ProviderNode21.class,
+    ProviderNode22.class,
+    ProviderNode23.class,
+    ProviderNode24.class,
+    ProviderNode25.class,
+    ProviderNode26.class,
+    ProviderNode27.class,
+    ProviderNode28.class,
+    ProviderNode29.class,
+    ProviderNode30.class,
+    ProviderNode31.class,
+    ProviderNode32.class,
+    ProviderNode33.class,
+    ProviderNode34.class,
+    ProviderNode35.class,
+    ProviderNode36.class,
+    ProviderNode37.class,
+    ProviderNode38.class,
+    ProviderNode39.class,
+    ProviderNode40.class,
+    ProviderNode41.class,
+    ProviderNode42.class,
+    ProviderNode43.class,
+    ProviderNode44.class,
+    ProviderNode45.class,
+    ProviderNode46.class,
+    ProviderNode47.class,
+    ProviderNode48.class,
+    ProviderNode49.class,
+    ProviderNode50.class,
+    ProviderNode51.class,
+    ProviderNode52.class,
+    ProviderNode53.class,
+    ProviderNode54.class,
+    ProviderNode55.class,
+    ProviderNode56.class,
+    ProviderNode57.class,
+    ProviderNode58.class,
+    ProviderNode59.class,
+    ProviderNode60.class,
+    ProviderNode61.class,
+    ProviderNode62.class,
+    ProviderNode63.class
+  };
+
+  @Benchmark
+  public Injector buildChain(ChainState state) {
+    return newInjector(CHAIN_CLASSES, state.classCount);
+  }
+
+  @Benchmark
+  public void getChainLeaf(ChainState state, Blackhole blackhole) {
+    blackhole.consume(state.injector.get(state.leafClass()));
+  }
+
+  @Benchmark
+  public void renderChain(ChainState state, Blackhole blackhole) {
+    blackhole.consume(state.injector.toString());
+  }
+
+  @Benchmark
+  public Injector buildSingletonChain(SingletonChainState state) {
+    return newInjector(SINGLETON_CHAIN_CLASSES, state.classCount);
+  }
+
+  @Benchmark
+  public void getSingletonChainLeafFirstTime(
+      SingletonFirstCreationState state, Blackhole blackhole) {
+    blackhole.consume(state.injector.get(state.leafClass()));
+  }
+
+  @Benchmark
+  public void getSingletonChainLeafCached(SingletonChainState state, Blackhole blackhole) {
+    blackhole.consume(state.injector.get(state.leafClass()));
+  }
+
+  @Benchmark
+  public Injector buildProviderGraph(ProviderGraphState state) {
+    return newProviderInjector(state.classCount);
+  }
+
+  @Benchmark
+  public void getProviderLeaf(ProviderGraphState state, Blackhole blackhole) {
+    blackhole.consume(state.injector.get(state.leafClass()));
+  }
+
+  @Benchmark
+  public void renderProviderGraph(ProviderGraphState state, Blackhole blackhole) {
+    blackhole.consume(state.injector.toString());
+  }
+
+  private static Injector newInjector(Class<?>[] classes, int classCount) {
+    checkClassCount(classes, classCount);
+    final var additionalClasses = Arrays.copyOfRange(classes, 1, classCount);
+    return Injector.injector().add(classes[0], additionalClasses).build();
+  }
+
+  private static Injector newProviderInjector(int classCount) {
+    checkClassCount(PROVIDER_FACTORY_CLASSES, classCount);
+    return Injector.injector().add(PROVIDER_FACTORY_CLASSES[classCount - 1]).build();
+  }
+
+  private static void checkClassCount(Class<?>[] classes, int classCount) {
+    if (classCount <= 0 || classCount > classes.length) {
+      throw new IllegalArgumentException("Class count must be between 1 and " + classes.length);
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    Main.main(args);
+  }
+
+  @State(Scope.Benchmark)
+  public static class ChainState {
+    @Param({"8", "32", "64"})
+    int classCount;
+
+    private Injector injector;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      injector = newInjector(CHAIN_CLASSES, classCount);
+    }
+
+    private Class<?> leafClass() {
+      return CHAIN_CLASSES[classCount - 1];
+    }
+  }
+
+  @State(Scope.Benchmark)
+  public static class SingletonChainState {
+    @Param({"8", "32", "64"})
+    int classCount;
+
+    private Injector injector;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      injector = newInjector(SINGLETON_CHAIN_CLASSES, classCount);
+      injector.get(leafClass());
+    }
+
+    private Class<?> leafClass() {
+      return SINGLETON_CHAIN_CLASSES[classCount - 1];
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class SingletonFirstCreationState {
+    @Param({"8", "32", "64"})
+    int classCount;
+
+    private Injector injector;
+
+    @Setup(Level.Invocation)
+    public void setup() {
+      injector = newInjector(SINGLETON_CHAIN_CLASSES, classCount);
+    }
+
+    private Class<?> leafClass() {
+      return SINGLETON_CHAIN_CLASSES[classCount - 1];
+    }
+  }
+
+  @State(Scope.Benchmark)
+  public static class ProviderGraphState {
+    @Param({"8", "32", "64"})
+    int classCount;
+
+    private Injector injector;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      injector = newProviderInjector(classCount);
+    }
+
+    private Class<?> leafClass() {
+      return PROVIDER_NODE_CLASSES[classCount - 1];
+    }
+  }
+
+  static class Chain00 {}
+
+  static class Chain01 {
+    @Inject
+    Chain01(Chain00 ignored) {}
+  }
+
+  static class Chain02 {
+    @Inject
+    Chain02(Chain01 ignored) {}
+  }
+
+  static class Chain03 {
+    @Inject
+    Chain03(Chain02 ignored) {}
+  }
+
+  static class Chain04 {
+    @Inject
+    Chain04(Chain03 ignored) {}
+  }
+
+  static class Chain05 {
+    @Inject
+    Chain05(Chain04 ignored) {}
+  }
+
+  static class Chain06 {
+    @Inject
+    Chain06(Chain05 ignored) {}
+  }
+
+  static class Chain07 {
+    @Inject
+    Chain07(Chain06 ignored) {}
+  }
+
+  static class Chain08 {
+    @Inject
+    Chain08(Chain07 ignored) {}
+  }
+
+  static class Chain09 {
+    @Inject
+    Chain09(Chain08 ignored) {}
+  }
+
+  static class Chain10 {
+    @Inject
+    Chain10(Chain09 ignored) {}
+  }
+
+  static class Chain11 {
+    @Inject
+    Chain11(Chain10 ignored) {}
+  }
+
+  static class Chain12 {
+    @Inject
+    Chain12(Chain11 ignored) {}
+  }
+
+  static class Chain13 {
+    @Inject
+    Chain13(Chain12 ignored) {}
+  }
+
+  static class Chain14 {
+    @Inject
+    Chain14(Chain13 ignored) {}
+  }
+
+  static class Chain15 {
+    @Inject
+    Chain15(Chain14 ignored) {}
+  }
+
+  static class Chain16 {
+    @Inject
+    Chain16(Chain15 ignored) {}
+  }
+
+  static class Chain17 {
+    @Inject
+    Chain17(Chain16 ignored) {}
+  }
+
+  static class Chain18 {
+    @Inject
+    Chain18(Chain17 ignored) {}
+  }
+
+  static class Chain19 {
+    @Inject
+    Chain19(Chain18 ignored) {}
+  }
+
+  static class Chain20 {
+    @Inject
+    Chain20(Chain19 ignored) {}
+  }
+
+  static class Chain21 {
+    @Inject
+    Chain21(Chain20 ignored) {}
+  }
+
+  static class Chain22 {
+    @Inject
+    Chain22(Chain21 ignored) {}
+  }
+
+  static class Chain23 {
+    @Inject
+    Chain23(Chain22 ignored) {}
+  }
+
+  static class Chain24 {
+    @Inject
+    Chain24(Chain23 ignored) {}
+  }
+
+  static class Chain25 {
+    @Inject
+    Chain25(Chain24 ignored) {}
+  }
+
+  static class Chain26 {
+    @Inject
+    Chain26(Chain25 ignored) {}
+  }
+
+  static class Chain27 {
+    @Inject
+    Chain27(Chain26 ignored) {}
+  }
+
+  static class Chain28 {
+    @Inject
+    Chain28(Chain27 ignored) {}
+  }
+
+  static class Chain29 {
+    @Inject
+    Chain29(Chain28 ignored) {}
+  }
+
+  static class Chain30 {
+    @Inject
+    Chain30(Chain29 ignored) {}
+  }
+
+  static class Chain31 {
+    @Inject
+    Chain31(Chain30 ignored) {}
+  }
+
+  static class Chain32 {
+    @Inject
+    Chain32(Chain31 ignored) {}
+  }
+
+  static class Chain33 {
+    @Inject
+    Chain33(Chain32 ignored) {}
+  }
+
+  static class Chain34 {
+    @Inject
+    Chain34(Chain33 ignored) {}
+  }
+
+  static class Chain35 {
+    @Inject
+    Chain35(Chain34 ignored) {}
+  }
+
+  static class Chain36 {
+    @Inject
+    Chain36(Chain35 ignored) {}
+  }
+
+  static class Chain37 {
+    @Inject
+    Chain37(Chain36 ignored) {}
+  }
+
+  static class Chain38 {
+    @Inject
+    Chain38(Chain37 ignored) {}
+  }
+
+  static class Chain39 {
+    @Inject
+    Chain39(Chain38 ignored) {}
+  }
+
+  static class Chain40 {
+    @Inject
+    Chain40(Chain39 ignored) {}
+  }
+
+  static class Chain41 {
+    @Inject
+    Chain41(Chain40 ignored) {}
+  }
+
+  static class Chain42 {
+    @Inject
+    Chain42(Chain41 ignored) {}
+  }
+
+  static class Chain43 {
+    @Inject
+    Chain43(Chain42 ignored) {}
+  }
+
+  static class Chain44 {
+    @Inject
+    Chain44(Chain43 ignored) {}
+  }
+
+  static class Chain45 {
+    @Inject
+    Chain45(Chain44 ignored) {}
+  }
+
+  static class Chain46 {
+    @Inject
+    Chain46(Chain45 ignored) {}
+  }
+
+  static class Chain47 {
+    @Inject
+    Chain47(Chain46 ignored) {}
+  }
+
+  static class Chain48 {
+    @Inject
+    Chain48(Chain47 ignored) {}
+  }
+
+  static class Chain49 {
+    @Inject
+    Chain49(Chain48 ignored) {}
+  }
+
+  static class Chain50 {
+    @Inject
+    Chain50(Chain49 ignored) {}
+  }
+
+  static class Chain51 {
+    @Inject
+    Chain51(Chain50 ignored) {}
+  }
+
+  static class Chain52 {
+    @Inject
+    Chain52(Chain51 ignored) {}
+  }
+
+  static class Chain53 {
+    @Inject
+    Chain53(Chain52 ignored) {}
+  }
+
+  static class Chain54 {
+    @Inject
+    Chain54(Chain53 ignored) {}
+  }
+
+  static class Chain55 {
+    @Inject
+    Chain55(Chain54 ignored) {}
+  }
+
+  static class Chain56 {
+    @Inject
+    Chain56(Chain55 ignored) {}
+  }
+
+  static class Chain57 {
+    @Inject
+    Chain57(Chain56 ignored) {}
+  }
+
+  static class Chain58 {
+    @Inject
+    Chain58(Chain57 ignored) {}
+  }
+
+  static class Chain59 {
+    @Inject
+    Chain59(Chain58 ignored) {}
+  }
+
+  static class Chain60 {
+    @Inject
+    Chain60(Chain59 ignored) {}
+  }
+
+  static class Chain61 {
+    @Inject
+    Chain61(Chain60 ignored) {}
+  }
+
+  static class Chain62 {
+    @Inject
+    Chain62(Chain61 ignored) {}
+  }
+
+  static class Chain63 {
+    @Inject
+    Chain63(Chain62 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain00 {}
+
+  @Singleton
+  static class SingletonChain01 {
+    @Inject
+    SingletonChain01(SingletonChain00 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain02 {
+    @Inject
+    SingletonChain02(SingletonChain01 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain03 {
+    @Inject
+    SingletonChain03(SingletonChain02 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain04 {
+    @Inject
+    SingletonChain04(SingletonChain03 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain05 {
+    @Inject
+    SingletonChain05(SingletonChain04 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain06 {
+    @Inject
+    SingletonChain06(SingletonChain05 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain07 {
+    @Inject
+    SingletonChain07(SingletonChain06 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain08 {
+    @Inject
+    SingletonChain08(SingletonChain07 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain09 {
+    @Inject
+    SingletonChain09(SingletonChain08 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain10 {
+    @Inject
+    SingletonChain10(SingletonChain09 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain11 {
+    @Inject
+    SingletonChain11(SingletonChain10 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain12 {
+    @Inject
+    SingletonChain12(SingletonChain11 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain13 {
+    @Inject
+    SingletonChain13(SingletonChain12 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain14 {
+    @Inject
+    SingletonChain14(SingletonChain13 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain15 {
+    @Inject
+    SingletonChain15(SingletonChain14 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain16 {
+    @Inject
+    SingletonChain16(SingletonChain15 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain17 {
+    @Inject
+    SingletonChain17(SingletonChain16 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain18 {
+    @Inject
+    SingletonChain18(SingletonChain17 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain19 {
+    @Inject
+    SingletonChain19(SingletonChain18 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain20 {
+    @Inject
+    SingletonChain20(SingletonChain19 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain21 {
+    @Inject
+    SingletonChain21(SingletonChain20 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain22 {
+    @Inject
+    SingletonChain22(SingletonChain21 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain23 {
+    @Inject
+    SingletonChain23(SingletonChain22 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain24 {
+    @Inject
+    SingletonChain24(SingletonChain23 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain25 {
+    @Inject
+    SingletonChain25(SingletonChain24 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain26 {
+    @Inject
+    SingletonChain26(SingletonChain25 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain27 {
+    @Inject
+    SingletonChain27(SingletonChain26 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain28 {
+    @Inject
+    SingletonChain28(SingletonChain27 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain29 {
+    @Inject
+    SingletonChain29(SingletonChain28 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain30 {
+    @Inject
+    SingletonChain30(SingletonChain29 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain31 {
+    @Inject
+    SingletonChain31(SingletonChain30 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain32 {
+    @Inject
+    SingletonChain32(SingletonChain31 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain33 {
+    @Inject
+    SingletonChain33(SingletonChain32 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain34 {
+    @Inject
+    SingletonChain34(SingletonChain33 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain35 {
+    @Inject
+    SingletonChain35(SingletonChain34 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain36 {
+    @Inject
+    SingletonChain36(SingletonChain35 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain37 {
+    @Inject
+    SingletonChain37(SingletonChain36 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain38 {
+    @Inject
+    SingletonChain38(SingletonChain37 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain39 {
+    @Inject
+    SingletonChain39(SingletonChain38 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain40 {
+    @Inject
+    SingletonChain40(SingletonChain39 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain41 {
+    @Inject
+    SingletonChain41(SingletonChain40 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain42 {
+    @Inject
+    SingletonChain42(SingletonChain41 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain43 {
+    @Inject
+    SingletonChain43(SingletonChain42 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain44 {
+    @Inject
+    SingletonChain44(SingletonChain43 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain45 {
+    @Inject
+    SingletonChain45(SingletonChain44 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain46 {
+    @Inject
+    SingletonChain46(SingletonChain45 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain47 {
+    @Inject
+    SingletonChain47(SingletonChain46 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain48 {
+    @Inject
+    SingletonChain48(SingletonChain47 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain49 {
+    @Inject
+    SingletonChain49(SingletonChain48 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain50 {
+    @Inject
+    SingletonChain50(SingletonChain49 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain51 {
+    @Inject
+    SingletonChain51(SingletonChain50 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain52 {
+    @Inject
+    SingletonChain52(SingletonChain51 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain53 {
+    @Inject
+    SingletonChain53(SingletonChain52 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain54 {
+    @Inject
+    SingletonChain54(SingletonChain53 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain55 {
+    @Inject
+    SingletonChain55(SingletonChain54 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain56 {
+    @Inject
+    SingletonChain56(SingletonChain55 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain57 {
+    @Inject
+    SingletonChain57(SingletonChain56 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain58 {
+    @Inject
+    SingletonChain58(SingletonChain57 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain59 {
+    @Inject
+    SingletonChain59(SingletonChain58 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain60 {
+    @Inject
+    SingletonChain60(SingletonChain59 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain61 {
+    @Inject
+    SingletonChain61(SingletonChain60 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain62 {
+    @Inject
+    SingletonChain62(SingletonChain61 ignored) {}
+  }
+
+  @Singleton
+  static class SingletonChain63 {
+    @Inject
+    SingletonChain63(SingletonChain62 ignored) {}
+  }
+
+  static class ProviderNode00 {}
+
+  static class ProviderNode01 {
+    final ProviderNode00 previous;
+
+    ProviderNode01(ProviderNode00 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode02 {
+    final ProviderNode01 previous;
+
+    ProviderNode02(ProviderNode01 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode03 {
+    final ProviderNode02 previous;
+
+    ProviderNode03(ProviderNode02 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode04 {
+    final ProviderNode03 previous;
+
+    ProviderNode04(ProviderNode03 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode05 {
+    final ProviderNode04 previous;
+
+    ProviderNode05(ProviderNode04 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode06 {
+    final ProviderNode05 previous;
+
+    ProviderNode06(ProviderNode05 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode07 {
+    final ProviderNode06 previous;
+
+    ProviderNode07(ProviderNode06 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode08 {
+    final ProviderNode07 previous;
+
+    ProviderNode08(ProviderNode07 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode09 {
+    final ProviderNode08 previous;
+
+    ProviderNode09(ProviderNode08 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode10 {
+    final ProviderNode09 previous;
+
+    ProviderNode10(ProviderNode09 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode11 {
+    final ProviderNode10 previous;
+
+    ProviderNode11(ProviderNode10 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode12 {
+    final ProviderNode11 previous;
+
+    ProviderNode12(ProviderNode11 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode13 {
+    final ProviderNode12 previous;
+
+    ProviderNode13(ProviderNode12 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode14 {
+    final ProviderNode13 previous;
+
+    ProviderNode14(ProviderNode13 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode15 {
+    final ProviderNode14 previous;
+
+    ProviderNode15(ProviderNode14 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode16 {
+    final ProviderNode15 previous;
+
+    ProviderNode16(ProviderNode15 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode17 {
+    final ProviderNode16 previous;
+
+    ProviderNode17(ProviderNode16 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode18 {
+    final ProviderNode17 previous;
+
+    ProviderNode18(ProviderNode17 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode19 {
+    final ProviderNode18 previous;
+
+    ProviderNode19(ProviderNode18 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode20 {
+    final ProviderNode19 previous;
+
+    ProviderNode20(ProviderNode19 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode21 {
+    final ProviderNode20 previous;
+
+    ProviderNode21(ProviderNode20 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode22 {
+    final ProviderNode21 previous;
+
+    ProviderNode22(ProviderNode21 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode23 {
+    final ProviderNode22 previous;
+
+    ProviderNode23(ProviderNode22 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode24 {
+    final ProviderNode23 previous;
+
+    ProviderNode24(ProviderNode23 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode25 {
+    final ProviderNode24 previous;
+
+    ProviderNode25(ProviderNode24 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode26 {
+    final ProviderNode25 previous;
+
+    ProviderNode26(ProviderNode25 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode27 {
+    final ProviderNode26 previous;
+
+    ProviderNode27(ProviderNode26 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode28 {
+    final ProviderNode27 previous;
+
+    ProviderNode28(ProviderNode27 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode29 {
+    final ProviderNode28 previous;
+
+    ProviderNode29(ProviderNode28 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode30 {
+    final ProviderNode29 previous;
+
+    ProviderNode30(ProviderNode29 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode31 {
+    final ProviderNode30 previous;
+
+    ProviderNode31(ProviderNode30 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode32 {
+    final ProviderNode31 previous;
+
+    ProviderNode32(ProviderNode31 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode33 {
+    final ProviderNode32 previous;
+
+    ProviderNode33(ProviderNode32 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode34 {
+    final ProviderNode33 previous;
+
+    ProviderNode34(ProviderNode33 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode35 {
+    final ProviderNode34 previous;
+
+    ProviderNode35(ProviderNode34 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode36 {
+    final ProviderNode35 previous;
+
+    ProviderNode36(ProviderNode35 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode37 {
+    final ProviderNode36 previous;
+
+    ProviderNode37(ProviderNode36 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode38 {
+    final ProviderNode37 previous;
+
+    ProviderNode38(ProviderNode37 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode39 {
+    final ProviderNode38 previous;
+
+    ProviderNode39(ProviderNode38 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode40 {
+    final ProviderNode39 previous;
+
+    ProviderNode40(ProviderNode39 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode41 {
+    final ProviderNode40 previous;
+
+    ProviderNode41(ProviderNode40 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode42 {
+    final ProviderNode41 previous;
+
+    ProviderNode42(ProviderNode41 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode43 {
+    final ProviderNode42 previous;
+
+    ProviderNode43(ProviderNode42 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode44 {
+    final ProviderNode43 previous;
+
+    ProviderNode44(ProviderNode43 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode45 {
+    final ProviderNode44 previous;
+
+    ProviderNode45(ProviderNode44 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode46 {
+    final ProviderNode45 previous;
+
+    ProviderNode46(ProviderNode45 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode47 {
+    final ProviderNode46 previous;
+
+    ProviderNode47(ProviderNode46 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode48 {
+    final ProviderNode47 previous;
+
+    ProviderNode48(ProviderNode47 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode49 {
+    final ProviderNode48 previous;
+
+    ProviderNode49(ProviderNode48 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode50 {
+    final ProviderNode49 previous;
+
+    ProviderNode50(ProviderNode49 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode51 {
+    final ProviderNode50 previous;
+
+    ProviderNode51(ProviderNode50 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode52 {
+    final ProviderNode51 previous;
+
+    ProviderNode52(ProviderNode51 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode53 {
+    final ProviderNode52 previous;
+
+    ProviderNode53(ProviderNode52 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode54 {
+    final ProviderNode53 previous;
+
+    ProviderNode54(ProviderNode53 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode55 {
+    final ProviderNode54 previous;
+
+    ProviderNode55(ProviderNode54 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode56 {
+    final ProviderNode55 previous;
+
+    ProviderNode56(ProviderNode55 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode57 {
+    final ProviderNode56 previous;
+
+    ProviderNode57(ProviderNode56 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode58 {
+    final ProviderNode57 previous;
+
+    ProviderNode58(ProviderNode57 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode59 {
+    final ProviderNode58 previous;
+
+    ProviderNode59(ProviderNode58 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode60 {
+    final ProviderNode59 previous;
+
+    ProviderNode60(ProviderNode59 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode61 {
+    final ProviderNode60 previous;
+
+    ProviderNode61(ProviderNode60 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode62 {
+    final ProviderNode61 previous;
+
+    ProviderNode62(ProviderNode61 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderNode63 {
+    final ProviderNode62 previous;
+
+    ProviderNode63(ProviderNode62 previous) {
+      this.previous = previous;
+    }
+  }
+
+  static class ProviderFactory00 {
+    @Provides
+    ProviderNode00 providerNode00() {
+      return new ProviderNode00();
+    }
+  }
+
+  static class ProviderFactory01 extends ProviderFactory00 {
+    @Provides
+    ProviderNode01 providerNode01(ProviderNode00 previous) {
+      return new ProviderNode01(previous);
+    }
+  }
+
+  static class ProviderFactory02 extends ProviderFactory01 {
+    @Provides
+    ProviderNode02 providerNode02(ProviderNode01 previous) {
+      return new ProviderNode02(previous);
+    }
+  }
+
+  static class ProviderFactory03 extends ProviderFactory02 {
+    @Provides
+    ProviderNode03 providerNode03(ProviderNode02 previous) {
+      return new ProviderNode03(previous);
+    }
+  }
+
+  static class ProviderFactory04 extends ProviderFactory03 {
+    @Provides
+    ProviderNode04 providerNode04(ProviderNode03 previous) {
+      return new ProviderNode04(previous);
+    }
+  }
+
+  static class ProviderFactory05 extends ProviderFactory04 {
+    @Provides
+    ProviderNode05 providerNode05(ProviderNode04 previous) {
+      return new ProviderNode05(previous);
+    }
+  }
+
+  static class ProviderFactory06 extends ProviderFactory05 {
+    @Provides
+    ProviderNode06 providerNode06(ProviderNode05 previous) {
+      return new ProviderNode06(previous);
+    }
+  }
+
+  static class ProviderFactory07 extends ProviderFactory06 {
+    @Provides
+    ProviderNode07 providerNode07(ProviderNode06 previous) {
+      return new ProviderNode07(previous);
+    }
+  }
+
+  static class ProviderFactory08 extends ProviderFactory07 {
+    @Provides
+    ProviderNode08 providerNode08(ProviderNode07 previous) {
+      return new ProviderNode08(previous);
+    }
+  }
+
+  static class ProviderFactory09 extends ProviderFactory08 {
+    @Provides
+    ProviderNode09 providerNode09(ProviderNode08 previous) {
+      return new ProviderNode09(previous);
+    }
+  }
+
+  static class ProviderFactory10 extends ProviderFactory09 {
+    @Provides
+    ProviderNode10 providerNode10(ProviderNode09 previous) {
+      return new ProviderNode10(previous);
+    }
+  }
+
+  static class ProviderFactory11 extends ProviderFactory10 {
+    @Provides
+    ProviderNode11 providerNode11(ProviderNode10 previous) {
+      return new ProviderNode11(previous);
+    }
+  }
+
+  static class ProviderFactory12 extends ProviderFactory11 {
+    @Provides
+    ProviderNode12 providerNode12(ProviderNode11 previous) {
+      return new ProviderNode12(previous);
+    }
+  }
+
+  static class ProviderFactory13 extends ProviderFactory12 {
+    @Provides
+    ProviderNode13 providerNode13(ProviderNode12 previous) {
+      return new ProviderNode13(previous);
+    }
+  }
+
+  static class ProviderFactory14 extends ProviderFactory13 {
+    @Provides
+    ProviderNode14 providerNode14(ProviderNode13 previous) {
+      return new ProviderNode14(previous);
+    }
+  }
+
+  static class ProviderFactory15 extends ProviderFactory14 {
+    @Provides
+    ProviderNode15 providerNode15(ProviderNode14 previous) {
+      return new ProviderNode15(previous);
+    }
+  }
+
+  static class ProviderFactory16 extends ProviderFactory15 {
+    @Provides
+    ProviderNode16 providerNode16(ProviderNode15 previous) {
+      return new ProviderNode16(previous);
+    }
+  }
+
+  static class ProviderFactory17 extends ProviderFactory16 {
+    @Provides
+    ProviderNode17 providerNode17(ProviderNode16 previous) {
+      return new ProviderNode17(previous);
+    }
+  }
+
+  static class ProviderFactory18 extends ProviderFactory17 {
+    @Provides
+    ProviderNode18 providerNode18(ProviderNode17 previous) {
+      return new ProviderNode18(previous);
+    }
+  }
+
+  static class ProviderFactory19 extends ProviderFactory18 {
+    @Provides
+    ProviderNode19 providerNode19(ProviderNode18 previous) {
+      return new ProviderNode19(previous);
+    }
+  }
+
+  static class ProviderFactory20 extends ProviderFactory19 {
+    @Provides
+    ProviderNode20 providerNode20(ProviderNode19 previous) {
+      return new ProviderNode20(previous);
+    }
+  }
+
+  static class ProviderFactory21 extends ProviderFactory20 {
+    @Provides
+    ProviderNode21 providerNode21(ProviderNode20 previous) {
+      return new ProviderNode21(previous);
+    }
+  }
+
+  static class ProviderFactory22 extends ProviderFactory21 {
+    @Provides
+    ProviderNode22 providerNode22(ProviderNode21 previous) {
+      return new ProviderNode22(previous);
+    }
+  }
+
+  static class ProviderFactory23 extends ProviderFactory22 {
+    @Provides
+    ProviderNode23 providerNode23(ProviderNode22 previous) {
+      return new ProviderNode23(previous);
+    }
+  }
+
+  static class ProviderFactory24 extends ProviderFactory23 {
+    @Provides
+    ProviderNode24 providerNode24(ProviderNode23 previous) {
+      return new ProviderNode24(previous);
+    }
+  }
+
+  static class ProviderFactory25 extends ProviderFactory24 {
+    @Provides
+    ProviderNode25 providerNode25(ProviderNode24 previous) {
+      return new ProviderNode25(previous);
+    }
+  }
+
+  static class ProviderFactory26 extends ProviderFactory25 {
+    @Provides
+    ProviderNode26 providerNode26(ProviderNode25 previous) {
+      return new ProviderNode26(previous);
+    }
+  }
+
+  static class ProviderFactory27 extends ProviderFactory26 {
+    @Provides
+    ProviderNode27 providerNode27(ProviderNode26 previous) {
+      return new ProviderNode27(previous);
+    }
+  }
+
+  static class ProviderFactory28 extends ProviderFactory27 {
+    @Provides
+    ProviderNode28 providerNode28(ProviderNode27 previous) {
+      return new ProviderNode28(previous);
+    }
+  }
+
+  static class ProviderFactory29 extends ProviderFactory28 {
+    @Provides
+    ProviderNode29 providerNode29(ProviderNode28 previous) {
+      return new ProviderNode29(previous);
+    }
+  }
+
+  static class ProviderFactory30 extends ProviderFactory29 {
+    @Provides
+    ProviderNode30 providerNode30(ProviderNode29 previous) {
+      return new ProviderNode30(previous);
+    }
+  }
+
+  static class ProviderFactory31 extends ProviderFactory30 {
+    @Provides
+    ProviderNode31 providerNode31(ProviderNode30 previous) {
+      return new ProviderNode31(previous);
+    }
+  }
+
+  static class ProviderFactory32 extends ProviderFactory31 {
+    @Provides
+    ProviderNode32 providerNode32(ProviderNode31 previous) {
+      return new ProviderNode32(previous);
+    }
+  }
+
+  static class ProviderFactory33 extends ProviderFactory32 {
+    @Provides
+    ProviderNode33 providerNode33(ProviderNode32 previous) {
+      return new ProviderNode33(previous);
+    }
+  }
+
+  static class ProviderFactory34 extends ProviderFactory33 {
+    @Provides
+    ProviderNode34 providerNode34(ProviderNode33 previous) {
+      return new ProviderNode34(previous);
+    }
+  }
+
+  static class ProviderFactory35 extends ProviderFactory34 {
+    @Provides
+    ProviderNode35 providerNode35(ProviderNode34 previous) {
+      return new ProviderNode35(previous);
+    }
+  }
+
+  static class ProviderFactory36 extends ProviderFactory35 {
+    @Provides
+    ProviderNode36 providerNode36(ProviderNode35 previous) {
+      return new ProviderNode36(previous);
+    }
+  }
+
+  static class ProviderFactory37 extends ProviderFactory36 {
+    @Provides
+    ProviderNode37 providerNode37(ProviderNode36 previous) {
+      return new ProviderNode37(previous);
+    }
+  }
+
+  static class ProviderFactory38 extends ProviderFactory37 {
+    @Provides
+    ProviderNode38 providerNode38(ProviderNode37 previous) {
+      return new ProviderNode38(previous);
+    }
+  }
+
+  static class ProviderFactory39 extends ProviderFactory38 {
+    @Provides
+    ProviderNode39 providerNode39(ProviderNode38 previous) {
+      return new ProviderNode39(previous);
+    }
+  }
+
+  static class ProviderFactory40 extends ProviderFactory39 {
+    @Provides
+    ProviderNode40 providerNode40(ProviderNode39 previous) {
+      return new ProviderNode40(previous);
+    }
+  }
+
+  static class ProviderFactory41 extends ProviderFactory40 {
+    @Provides
+    ProviderNode41 providerNode41(ProviderNode40 previous) {
+      return new ProviderNode41(previous);
+    }
+  }
+
+  static class ProviderFactory42 extends ProviderFactory41 {
+    @Provides
+    ProviderNode42 providerNode42(ProviderNode41 previous) {
+      return new ProviderNode42(previous);
+    }
+  }
+
+  static class ProviderFactory43 extends ProviderFactory42 {
+    @Provides
+    ProviderNode43 providerNode43(ProviderNode42 previous) {
+      return new ProviderNode43(previous);
+    }
+  }
+
+  static class ProviderFactory44 extends ProviderFactory43 {
+    @Provides
+    ProviderNode44 providerNode44(ProviderNode43 previous) {
+      return new ProviderNode44(previous);
+    }
+  }
+
+  static class ProviderFactory45 extends ProviderFactory44 {
+    @Provides
+    ProviderNode45 providerNode45(ProviderNode44 previous) {
+      return new ProviderNode45(previous);
+    }
+  }
+
+  static class ProviderFactory46 extends ProviderFactory45 {
+    @Provides
+    ProviderNode46 providerNode46(ProviderNode45 previous) {
+      return new ProviderNode46(previous);
+    }
+  }
+
+  static class ProviderFactory47 extends ProviderFactory46 {
+    @Provides
+    ProviderNode47 providerNode47(ProviderNode46 previous) {
+      return new ProviderNode47(previous);
+    }
+  }
+
+  static class ProviderFactory48 extends ProviderFactory47 {
+    @Provides
+    ProviderNode48 providerNode48(ProviderNode47 previous) {
+      return new ProviderNode48(previous);
+    }
+  }
+
+  static class ProviderFactory49 extends ProviderFactory48 {
+    @Provides
+    ProviderNode49 providerNode49(ProviderNode48 previous) {
+      return new ProviderNode49(previous);
+    }
+  }
+
+  static class ProviderFactory50 extends ProviderFactory49 {
+    @Provides
+    ProviderNode50 providerNode50(ProviderNode49 previous) {
+      return new ProviderNode50(previous);
+    }
+  }
+
+  static class ProviderFactory51 extends ProviderFactory50 {
+    @Provides
+    ProviderNode51 providerNode51(ProviderNode50 previous) {
+      return new ProviderNode51(previous);
+    }
+  }
+
+  static class ProviderFactory52 extends ProviderFactory51 {
+    @Provides
+    ProviderNode52 providerNode52(ProviderNode51 previous) {
+      return new ProviderNode52(previous);
+    }
+  }
+
+  static class ProviderFactory53 extends ProviderFactory52 {
+    @Provides
+    ProviderNode53 providerNode53(ProviderNode52 previous) {
+      return new ProviderNode53(previous);
+    }
+  }
+
+  static class ProviderFactory54 extends ProviderFactory53 {
+    @Provides
+    ProviderNode54 providerNode54(ProviderNode53 previous) {
+      return new ProviderNode54(previous);
+    }
+  }
+
+  static class ProviderFactory55 extends ProviderFactory54 {
+    @Provides
+    ProviderNode55 providerNode55(ProviderNode54 previous) {
+      return new ProviderNode55(previous);
+    }
+  }
+
+  static class ProviderFactory56 extends ProviderFactory55 {
+    @Provides
+    ProviderNode56 providerNode56(ProviderNode55 previous) {
+      return new ProviderNode56(previous);
+    }
+  }
+
+  static class ProviderFactory57 extends ProviderFactory56 {
+    @Provides
+    ProviderNode57 providerNode57(ProviderNode56 previous) {
+      return new ProviderNode57(previous);
+    }
+  }
+
+  static class ProviderFactory58 extends ProviderFactory57 {
+    @Provides
+    ProviderNode58 providerNode58(ProviderNode57 previous) {
+      return new ProviderNode58(previous);
+    }
+  }
+
+  static class ProviderFactory59 extends ProviderFactory58 {
+    @Provides
+    ProviderNode59 providerNode59(ProviderNode58 previous) {
+      return new ProviderNode59(previous);
+    }
+  }
+
+  static class ProviderFactory60 extends ProviderFactory59 {
+    @Provides
+    ProviderNode60 providerNode60(ProviderNode59 previous) {
+      return new ProviderNode60(previous);
+    }
+  }
+
+  static class ProviderFactory61 extends ProviderFactory60 {
+    @Provides
+    ProviderNode61 providerNode61(ProviderNode60 previous) {
+      return new ProviderNode61(previous);
+    }
+  }
+
+  static class ProviderFactory62 extends ProviderFactory61 {
+    @Provides
+    ProviderNode62 providerNode62(ProviderNode61 previous) {
+      return new ProviderNode62(previous);
+    }
+  }
+
+  static class ProviderFactory63 extends ProviderFactory62 {
+    @Provides
+    ProviderNode63 providerNode63(ProviderNode62 previous) {
+      return new ProviderNode63(previous);
+    }
+  }
+}

--- a/src/main/java/io/github/suppierk/inject/FieldInformation.java
+++ b/src/main/java/io/github/suppierk/inject/FieldInformation.java
@@ -26,14 +26,15 @@ package io.github.suppierk.inject;
 import java.lang.reflect.Field;
 import java.util.Objects;
 import java.util.StringJoiner;
+import org.jspecify.annotations.Nullable;
 
 /** Defines base information about specific class field. */
 public final class FieldInformation {
   private final Field field;
   private final Key<?> key;
-  private final Class<?> wrapper;
+  private final @Nullable Class<?> wrapper;
 
-  public FieldInformation(Field field, Key<?> key, Class<?> wrapper) {
+  public FieldInformation(@Nullable Field field, @Nullable Key<?> key, @Nullable Class<?> wrapper) {
     if (field == null) {
       throw new IllegalArgumentException("Field is null");
     }
@@ -57,12 +58,12 @@ public final class FieldInformation {
   }
 
   @SuppressWarnings("squid:S1452")
-  public Class<?> getWrapper() {
+  public @Nullable Class<?> getWrapper() {
     return wrapper;
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof FieldInformation)) return false;
     FieldInformation that = (FieldInformation) o;
     return Objects.equals(field, that.field)

--- a/src/main/java/io/github/suppierk/inject/Injector.java
+++ b/src/main/java/io/github/suppierk/inject/Injector.java
@@ -33,6 +33,7 @@ import io.github.suppierk.inject.graph.ReflectionNode;
 import io.github.suppierk.inject.graph.Value;
 import io.github.suppierk.inject.query.KeyAnnotationsPredicate;
 import io.github.suppierk.utils.ConsoleConstants;
+import io.github.suppierk.utils.Memoized;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Qualifier;
@@ -44,15 +45,17 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
 import java.util.AbstractMap;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -60,11 +63,15 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Main dependency injection functionality entry point.
@@ -80,6 +87,9 @@ public final class Injector implements Closeable {
   private static final String MULTIPLE_VALUES_TEMPLATE =
       "Multiple values available for %s and predicate %s";
   private static final String ALREADY_REPLACED_VALUE_TEMPLATE = "Already replaced: %s";
+  private static final String CAPTIVE_DEPENDENCY_TEMPLATE =
+      "Captive dependency detected: @Singleton %s depends directly on non-singleton %s. "
+          + "Mark %s as @Singleton, register it as an object, or inject Provider<%s>/Supplier<%s> instead.";
   private static final String CYCLE_TEMPLATE = "Found cycle: %s";
   private static final String MULTIPLE_INJECT_CONSTRUCTORS_TEMPLATE =
       "Multiple @Inject constructors found for class: %s";
@@ -96,9 +106,16 @@ public final class Injector implements Closeable {
       "Expected to have non-generic, plain class";
   private static final String NON_INSTANTIABLE_CLASS_TEMPLATE =
       "Class is abstract or an interface and cannot be instantiated";
+  private static final Comparator<Annotation> ANNOTATION_COMPARATOR =
+      Comparator.comparing((Annotation annotation) -> annotation.annotationType().getName())
+          .thenComparing(Annotation::toString);
+  private static final Comparator<Key<?>> KEY_COMPARATOR =
+      Comparator.comparing((Key<?> key) -> key.type().getName())
+          .thenComparing(Injector::annotationSortValue);
 
   private final Node<Injector> currentInjector;
   private final Map<Key<?>, Node<?>> providers;
+  private final AtomicBoolean closed;
 
   /**
    * Default constructor.
@@ -111,6 +128,7 @@ public final class Injector implements Closeable {
 
     this.providers = Map.copyOf(providers);
     this.currentInjector = new Value<>(injectorReference, Injector.this);
+    this.closed = new AtomicBoolean(false);
   }
 
   /**
@@ -123,7 +141,7 @@ public final class Injector implements Closeable {
    * @return initialized instance
    * @throws IllegalArgumentException if the class argument is {@code null}
    */
-  public <T> T get(Class<T> clazz) {
+  public <T> T get(@Nullable Class<T> clazz) {
     if (clazz == null) {
       throw new IllegalArgumentException(String.format(NULL_VALUE_TEMPLATE, "Class"));
     }
@@ -143,9 +161,9 @@ public final class Injector implements Closeable {
    * @param key to retrieve
    * @param <T> is the type of the instance
    * @return initialized instance
-   * @throws IllegalArgumentException if the class argument is {@code null}
+   * @throws IllegalArgumentException if the key argument is {@code null}
    */
-  public <T> T get(Key<T> key) {
+  public <T> T get(@Nullable Key<T> key) {
     if (key == null) {
       throw new IllegalArgumentException(String.format(NULL_VALUE_TEMPLATE, "Key"));
     }
@@ -166,7 +184,7 @@ public final class Injector implements Closeable {
    * @throws IllegalStateException if there is more than one dependency match
    */
   public <T> Optional<Key<T>> findOne(
-      Class<T> clazz, KeyAnnotationsPredicate keyAnnotationsPredicate) {
+      @Nullable Class<T> clazz, @Nullable KeyAnnotationsPredicate keyAnnotationsPredicate) {
     final var keys = findAll(clazz, keyAnnotationsPredicate);
 
     if (keys.isEmpty()) {
@@ -192,7 +210,8 @@ public final class Injector implements Closeable {
    * @throws IllegalArgumentException if class or predicate arguments is {@code null}
    */
   @SuppressWarnings("unchecked")
-  public <T> List<Key<T>> findAll(Class<T> clazz, KeyAnnotationsPredicate keyAnnotationsPredicate) {
+  public <T> List<Key<T>> findAll(
+      @Nullable Class<T> clazz, @Nullable KeyAnnotationsPredicate keyAnnotationsPredicate) {
     if (clazz == null) {
       throw new IllegalArgumentException(String.format(NULL_VALUE_TEMPLATE, "Class"));
     }
@@ -218,10 +237,10 @@ public final class Injector implements Closeable {
    * @param clazz to find
    * @return an {@link Optional} {@link Key} which can be used to retrieve dependency
    * @param <T> is the type of the instance
-   * @throws IllegalArgumentException if class or predicate arguments is {@code null}
+   * @throws IllegalArgumentException if class argument is {@code null}
    * @throws IllegalStateException if there is more than one dependency match
    */
-  public <T> Optional<Key<T>> findOne(Class<T> clazz) {
+  public <T> Optional<Key<T>> findOne(@Nullable Class<T> clazz) {
     return findOne(clazz, KeyAnnotationsPredicate.alwaysMatch());
   }
 
@@ -231,9 +250,9 @@ public final class Injector implements Closeable {
    * @param clazz to find
    * @return a {@link List} of {@link Key}s which can be used to retrieve dependencies
    * @param <T> is the type of the instance
-   * @throws IllegalArgumentException if class or predicate arguments is {@code null}
+   * @throws IllegalArgumentException if class argument is {@code null}
    */
-  public <T> List<Key<T>> findAll(Class<T> clazz) {
+  public <T> List<Key<T>> findAll(@Nullable Class<T> clazz) {
     return findAll(clazz, KeyAnnotationsPredicate.alwaysMatch());
   }
 
@@ -248,7 +267,7 @@ public final class Injector implements Closeable {
    */
   @SuppressWarnings("unchecked")
   <T> Node<T> getNode(Key<T> key) {
-    if (Injector.class.equals(key.type())) {
+    if (isUnqualifiedInjectorKey(key)) {
       return (Node<T>) currentInjector;
     }
 
@@ -276,6 +295,10 @@ public final class Injector implements Closeable {
   /** {@inheritDoc} */
   @Override
   public void close() {
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+
     final var keys = topologicallySortedKeys(providers);
 
     // Going in the reverse order to close dependencies
@@ -290,7 +313,7 @@ public final class Injector implements Closeable {
 
   /** {@inheritDoc} */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof Injector)) return false;
     Injector injector = (Injector) o;
     return Objects.equals(providers, injector.providers);
@@ -316,8 +339,19 @@ public final class Injector implements Closeable {
                         key ->
                             String.format(
                                 "%s%n%s",
-                                key.toYamlString(true, 1), providers.get(key).toYamlString(2)))
+                                key.toYamlString(true, 1),
+                                Objects.requireNonNull(providers.get(key)).toYamlString(2)))
                     .collect(Collectors.joining(String.format("%n%n")))));
+  }
+
+  /**
+   * Checks whether the key represents the injector's built-in unqualified self-reference.
+   *
+   * @param key to check
+   * @return {@code true} if the key requests {@link Injector} without qualifier annotations
+   */
+  private static boolean isUnqualifiedInjectorKey(Key<?> key) {
+    return Injector.class.equals(key.type()) && key.annotations().isEmpty();
   }
 
   /**
@@ -327,7 +361,7 @@ public final class Injector implements Closeable {
    * @return an immutable {@link Set} of {@link Qualifier} annotations
    */
   private static Set<Annotation> getQualifierAnnotations(Annotation[] annotations) {
-    if (annotations == null || annotations.length == 0) {
+    if (annotations.length == 0) {
       return Set.of();
     }
 
@@ -349,24 +383,35 @@ public final class Injector implements Closeable {
    * <p>At the very least, this will ensure that root dependencies will be closer to the top of the
    * list.
    *
+   * @param providers dependency graph nodes keyed by injectable keys
    * @return topologically sorted dependencies.
    */
   private static List<Key<?>> topologicallySortedKeys(Map<Key<?>, Node<?>> providers) {
     final var inDegreeMap = new HashMap<Key<?>, Integer>(providers.size());
+    final var childrenByParent = new HashMap<Key<?>, List<Key<?>>>(providers.size());
+
+    for (Key<?> key : providers.keySet()) {
+      childrenByParent.put(key, new ArrayList<>());
+    }
+
     for (Map.Entry<Key<?>, Node<?>> entry : providers.entrySet()) {
-      final var parents = entry.getValue().requiredParentKeys();
       int inbound = 0;
 
-      for (Key<?> parent : parents) {
+      for (Key<?> parent : entry.getValue().requiredParentKeys()) {
         if (providers.containsKey(parent)) {
           inbound++;
+          Objects.requireNonNull(childrenByParent.get(parent)).add(entry.getKey());
         }
       }
 
       inDegreeMap.put(entry.getKey(), inbound);
     }
 
-    final var nodesWithNoIncomingEdges = new ArrayDeque<Key<?>>(providers.size());
+    for (List<Key<?>> children : childrenByParent.values()) {
+      children.sort(KEY_COMPARATOR);
+    }
+
+    final var nodesWithNoIncomingEdges = new PriorityQueue<>(KEY_COMPARATOR);
     for (Map.Entry<Key<?>, Integer> entry : inDegreeMap.entrySet()) {
       if (entry.getValue() == 0) {
         nodesWithNoIncomingEdges.add(entry.getKey());
@@ -375,32 +420,117 @@ public final class Injector implements Closeable {
 
     final var topologicalOrder = new ArrayList<Key<?>>(providers.size());
     while (!nodesWithNoIncomingEdges.isEmpty()) {
-      final var key = nodesWithNoIncomingEdges.pollFirst();
+      final var key = nodesWithNoIncomingEdges.poll();
       topologicalOrder.add(key);
 
-      for (Map.Entry<Key<?>, Node<?>> entry : providers.entrySet()) {
-        final var currentParents = entry.getValue().requiredParentKeys();
+      for (Key<?> child : Objects.requireNonNull(childrenByParent.get(key))) {
+        final int previous = Objects.requireNonNull(inDegreeMap.get(child));
 
-        if (currentParents.contains(key)) {
-          if (!providers.containsKey(entry.getKey())) {
-            continue;
-          }
+        if (previous > 0) {
+          final int updated = previous - 1;
+          inDegreeMap.put(child, updated);
 
-          final var previous = inDegreeMap.get(entry.getKey());
-
-          if (previous > 0) {
-            final int updated = previous - 1;
-            inDegreeMap.put(entry.getKey(), updated);
-
-            if (updated == 0) {
-              nodesWithNoIncomingEdges.add(entry.getKey());
-            }
+          if (updated == 0) {
+            nodesWithNoIncomingEdges.add(child);
           }
         }
       }
     }
 
     return List.copyOf(topologicalOrder);
+  }
+
+  /**
+   * Creates deterministic string representation of key annotations for sorting.
+   *
+   * @param key to create annotation sort value for
+   * @return deterministic annotation sort value
+   */
+  private static String annotationSortValue(Key<?> key) {
+    return key.annotations().stream()
+        .sorted(ANNOTATION_COMPARATOR)
+        .map(Annotation::toString)
+        .collect(Collectors.joining("\n"));
+  }
+
+  private static final class AdjustedNode<T> extends Node<T> {
+    private final Node<T> delegate;
+    private final BiConsumer<Injector, ? super T> adjuster;
+    private final boolean singleton;
+    private final Supplier<T> supplier;
+
+    /**
+     * Default constructor.
+     *
+     * @param injectorReference for dependency lookups
+     * @param delegate node to create and adjust values with
+     * @param adjuster to tweak created instances after injection
+     * @param singleton whether adjusted values must be memoized
+     */
+    private AdjustedNode(
+        InjectorReference injectorReference,
+        Node<T> delegate,
+        BiConsumer<Injector, ? super T> adjuster,
+        boolean singleton) {
+      super(injectorReference, delegate.parentKeys());
+
+      this.delegate = delegate;
+      this.adjuster = adjuster;
+      this.singleton = singleton;
+      this.supplier =
+          singleton ? Memoized.memoizedProvider(this::createAdjusted) : this::createAdjusted;
+    }
+
+    @Override
+    public T get() {
+      return supplier.get();
+    }
+
+    @Override
+    public Set<Key<?>> requiredParentKeys() {
+      return delegate.requiredParentKeys();
+    }
+
+    @Override
+    public Node<T> copy(InjectorReference newInjector) {
+      return new AdjustedNode<>(newInjector, delegate.copy(newInjector), adjuster, singleton);
+    }
+
+    @Override
+    public String toYamlString(int indentationLevel) {
+      return delegate.toYamlString(indentationLevel);
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+      if (!(o instanceof AdjustedNode)) return false;
+      if (!super.equals(o)) return false;
+      AdjustedNode<?> that = (AdjustedNode<?>) o;
+      return singleton == that.singleton
+          && Objects.equals(delegate, that.delegate)
+          && Objects.equals(adjuster, that.adjuster);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), delegate, adjuster, singleton);
+    }
+
+    /**
+     * Creates value via delegate node and applies adjuster to it.
+     *
+     * @return adjusted value
+     */
+    private T createAdjusted() {
+      final var instance = delegate.get();
+      adjuster.accept(injectorReference().get(), instance);
+      return instance;
+    }
   }
 
   /** Contains additional logic to help construct {@link Injector} */
@@ -417,16 +547,37 @@ public final class Injector implements Closeable {
      * @param additionalClasses to add
      * @return current builder
      */
-    public Builder add(Class<?> clazz, Class<?>... additionalClasses) {
-      addClass(clazz);
+    public Builder add(@Nullable Class<?> clazz, Class<?> @Nullable ... additionalClasses) {
+      return synchronizeMutation(
+          this,
+          () -> {
+            addClass(clazz);
 
-      if (additionalClasses != null) {
-        for (Class<?> additionalClass : additionalClasses) {
-          addClass(additionalClass);
-        }
+            if (additionalClasses != null) {
+              for (Class<?> additionalClass : additionalClasses) {
+                addClass(additionalClass);
+              }
+            }
+          });
+    }
+
+    /**
+     * Adds class to the {@link Injector} with a post-construction adjuster.
+     *
+     * <p>The adjuster runs after constructor and field injection.
+     *
+     * @param clazz to add
+     * @param adjuster to tweak created instances after injection
+     * @return current builder
+     * @param <T> is the type of the added class
+     */
+    public <T> Builder add(
+        @Nullable Class<T> clazz, @Nullable BiConsumer<Injector, ? super T> adjuster) {
+      if (adjuster == null) {
+        throw new IllegalArgumentException(String.format(NULL_VALUE_TEMPLATE, "Adjuster"));
       }
 
-      return this;
+      return synchronizeMutation(this, () -> addClass(clazz, adjuster));
     }
 
     /**
@@ -436,16 +587,18 @@ public final class Injector implements Closeable {
      * @param additionalObjects to add
      * @return current builder
      */
-    public Builder add(Object object, Object... additionalObjects) {
-      addObject(object);
+    public Builder add(@Nullable Object object, Object @Nullable ... additionalObjects) {
+      return synchronizeMutation(
+          this,
+          () -> {
+            addObject(object);
 
-      if (additionalObjects != null) {
-        for (Object additionalObject : additionalObjects) {
-          addObject(additionalObject);
-        }
-      }
-
-      return this;
+            if (additionalObjects != null) {
+              for (Object additionalObject : additionalObjects) {
+                addObject(additionalObject);
+              }
+            }
+          });
     }
 
     /**
@@ -460,7 +613,19 @@ public final class Injector implements Closeable {
      * @throws IllegalArgumentException if class is {@code null}, {@code abstract} or {@code
      *     interface}, as well as from any methods called by this method
      */
-    private void addClass(Class<?> clazz) {
+    private void addClass(@Nullable Class<?> clazz) {
+      addClass(clazz, null);
+    }
+
+    /**
+     * Adds a class to the {@link Injector} with an optional post-construction adjuster.
+     *
+     * @param clazz to add
+     * @param adjuster to tweak created instances after injection, or {@code null} if not needed
+     * @param <T> is the type of the added class
+     */
+    private <T> void addClass(
+        @Nullable Class<T> clazz, @Nullable BiConsumer<Injector, ? super T> adjuster) {
       if (clazz == null) {
         throw new IllegalArgumentException(String.format(NULL_VALUE_TEMPLATE, "Class"));
       }
@@ -469,20 +634,15 @@ public final class Injector implements Closeable {
         throw new IllegalArgumentException(NON_INSTANTIABLE_CLASS_TEMPLATE);
       }
 
-      synchronize(
-          () -> {
-            parseClassForGraph(clazz, false);
+      parseClassForGraph(clazz, false, adjuster);
 
-            if (isNestedNonStaticClass(clazz)) {
-              Class<?> current = clazz.getEnclosingClass();
-              do {
-                parseClassForGraph(current, true);
-                current = current.getEnclosingClass();
-              } while (current != null);
-            }
-
-            return this;
-          });
+      if (isNestedNonStaticClass(clazz)) {
+        Class<?> current = clazz.getEnclosingClass();
+        do {
+          parseClassForGraph(current, true, null);
+          current = current.getEnclosingClass();
+        } while (current != null);
+      }
     }
 
     /**
@@ -492,7 +652,7 @@ public final class Injector implements Closeable {
      * @throws IllegalArgumentException if the value is {@code null} or graph already contains this
      *     value
      */
-    private void addObject(Object value) {
+    private void addObject(@Nullable Object value) {
       if (value == null) {
         throw new IllegalArgumentException(String.format(NULL_VALUE_TEMPLATE, "Value"));
       }
@@ -500,15 +660,11 @@ public final class Injector implements Closeable {
       final var classKey =
           new Key<>(value.getClass(), getQualifierAnnotations(value.getClass().getAnnotations()));
 
-      synchronize(
-          () -> {
-            if (providers.containsKey(classKey)) {
-              throw new IllegalArgumentException(String.format(DUPLICATE_VALUE_TEMPLATE, classKey));
-            }
+      if (providers.containsKey(classKey)) {
+        throw new IllegalArgumentException(String.format(DUPLICATE_VALUE_TEMPLATE, classKey));
+      }
 
-            providers.put(classKey, new Value<>(injectorReference, value));
-            return this;
-          });
+      providers.put(classKey, new Value<>(injectorReference, value));
     }
   }
 
@@ -542,18 +698,74 @@ public final class Injector implements Closeable {
      * @throws IllegalArgumentException if any of the arguments is {@code null} or from another
      *     method invocations
      */
-    public <F, T extends F> CopyBuilder replace(Class<F> from, Class<T> to) {
-      checkArguments(from, to);
+    public <F, T extends F> CopyBuilder replace(@Nullable Class<F> from, @Nullable Class<T> to) {
+      return replaceClass(from, to, null);
+    }
 
-      if (from.equals(to)) {
+    /**
+     * Replaces existing class onto another class with a post-construction adjuster.
+     *
+     * <p>The adjuster runs after constructor and field injection.
+     *
+     * @param from class to be replaced
+     * @param to class to replace to
+     * @param adjuster to tweak created instances after injection
+     * @param <F> is the type of existing class
+     * @param <T> is the type of the new class, which is expected to be a subtype of the original
+     *     class
+     * @return current builder instance
+     * @throws IllegalArgumentException if any of the arguments is {@code null} or from another
+     *     method invocations
+     */
+    public <F, T extends F> CopyBuilder replace(
+        @Nullable Class<F> from,
+        @Nullable Class<T> to,
+        @Nullable BiConsumer<Injector, ? super T> adjuster) {
+      if (adjuster == null) {
+        throw new IllegalArgumentException(String.format(NULL_VALUE_TEMPLATE, "Adjuster"));
+      }
+
+      return replaceClass(from, to, adjuster);
+    }
+
+    /**
+     * Replaces existing class registration with another class registration.
+     *
+     * @param from class to be replaced
+     * @param to class to replace to
+     * @param adjuster to tweak created replacement instances after injection, or {@code null} if
+     *     not needed
+     * @param <F> is the type of existing class
+     * @param <T> is the type of the new class, which is expected to be a subtype of the original
+     *     class
+     * @return current builder instance
+     */
+    private <F, T extends F> CopyBuilder replaceClass(
+        @Nullable Class<F> from,
+        @Nullable Class<T> to,
+        @Nullable BiConsumer<Injector, ? super T> adjuster) {
+      checkArguments(from, to);
+      final var sourceClass = Objects.requireNonNull(from);
+      final var targetClass = Objects.requireNonNull(to);
+
+      if (sourceClass.equals(targetClass)) {
         return this;
       }
 
-      final var keys = createKeys(from, to);
+      if (!sourceClass.isAssignableFrom(targetClass)) {
+        throw new IllegalArgumentException(NON_INSTANTIABLE_CLASS_TEMPLATE);
+      }
+
+      if (Modifier.isAbstract(targetClass.getModifiers())
+          || Modifier.isInterface(targetClass.getModifiers())) {
+        throw new IllegalArgumentException(NON_INSTANTIABLE_CLASS_TEMPLATE);
+      }
+
+      final var keys = createKeys(sourceClass, targetClass);
 
       // Closed via Injector.close()
       @SuppressWarnings("squid:S2095")
-      final var node = createConstructsNode(to);
+      final var node = createConstructsNode(targetClass, adjuster);
 
       return synchronize(
           () -> {
@@ -575,19 +787,31 @@ public final class Injector implements Closeable {
      * @throws IllegalArgumentException if any of the arguments is {@code null} or from another
      *     method invocations
      */
-    public <F, T extends F> CopyBuilder replace(F from, T to) {
+    public <F, T extends F> CopyBuilder replace(@Nullable F from, @Nullable T to) {
       checkArguments(from, to);
+      final var source = Objects.requireNonNull(from);
+      final var target = Objects.requireNonNull(to);
 
-      if (from.equals(to)) {
+      if (source.equals(target)) {
         return this;
       }
 
-      final var keys = createKeys(from.getClass(), to.getClass());
+      if (!source.getClass().isAssignableFrom(target.getClass())) {
+        throw new IllegalArgumentException(NON_INSTANTIABLE_CLASS_TEMPLATE);
+      }
+
+      final var keys = createKeys(source.getClass(), target.getClass());
 
       return synchronize(
           () -> {
+            final var currentNode = providers.get(keys.getKey());
+            if (!(currentNode instanceof Value<?>) || currentNode.get() != source) {
+              throw new IllegalArgumentException(
+                  String.format(MISSING_VALUE_TEMPLATE, keys.getKey()));
+            }
+
             providers.put(keys.getKey(), new RefersTo<>(injectorReference, keys.getValue()));
-            providers.put(keys.getValue(), new Value<>(injectorReference, to));
+            providers.put(keys.getValue(), new Value<>(injectorReference, target));
             return this;
           });
     }
@@ -598,7 +822,7 @@ public final class Injector implements Closeable {
      * @param from parameter to check
      * @param to parameter to check
      */
-    private void checkArguments(Object from, Object to) {
+    private void checkArguments(@Nullable Object from, @Nullable Object to) {
       if (from == null) {
         throw new IllegalArgumentException(String.format(NULL_VALUE_TEMPLATE, "From"));
       }
@@ -616,7 +840,7 @@ public final class Injector implements Closeable {
      * @param <F> is the type of existing class
      * @param <T> is the type of the new class, which is expected to be a subtype of the original
      *     class
-     * @return current builder instance
+     * @return immutable entry where key is source key and value is replacement key
      * @throws IllegalArgumentException if {@code from} was not present before or has been replaced,
      *     or {@code to} is already registered
      */
@@ -664,15 +888,27 @@ public final class Injector implements Closeable {
     public final Injector build() {
       return synchronize(
           () -> {
-            for (Node<?> node : providers.values()) {
-              for (Key<?> key : node.parentKeys()) {
-                if (!Injector.class.equals(key.type()) && !providers.containsKey(key)) {
+            for (Map.Entry<Key<?>, Node<?>> entry : providers.entrySet()) {
+              for (Key<?> key : entry.getValue().parentKeys()) {
+                if (!isUnqualifiedInjectorKey(key) && !providers.containsKey(key)) {
                   throw new IllegalArgumentException(String.format(MISSING_VALUE_TEMPLATE, key));
                 }
               }
             }
 
-            return new Injector(injectorReference, Map.copyOf(providers));
+            checkForCaptiveDependencies();
+
+            for (Map.Entry<Key<?>, Node<?>> entry : providers.entrySet()) {
+              checkForCycle(entry.getKey(), entry.getValue());
+            }
+
+            final var newInjectorReference = new InjectorReference();
+            final var copiedProviders = new HashMap<Key<?>, Node<?>>(providers.size());
+            for (Map.Entry<Key<?>, Node<?>> entry : providers.entrySet()) {
+              copiedProviders.put(entry.getKey(), entry.getValue().copy(newInjectorReference));
+            }
+
+            return new Injector(newInjectorReference, Map.copyOf(copiedProviders));
           });
     }
 
@@ -695,6 +931,31 @@ public final class Injector implements Closeable {
     }
 
     /**
+     * Runs a mutating builder operation under {@link Lock}, rolling back provider changes if the
+     * operation fails.
+     *
+     * @param builder to return after successful mutation
+     * @param mutation to run
+     * @param <B> is the type of the builder
+     * @return provided builder after successful mutation
+     */
+    protected final <B extends AbstractBuilder> B synchronizeMutation(
+        B builder, Runnable mutation) {
+      return synchronize(
+          () -> {
+            final var snapshot = new HashMap<>(providers);
+            try {
+              mutation.run();
+              return builder;
+            } catch (RuntimeException e) {
+              providers.clear();
+              providers.putAll(snapshot);
+              throw e;
+            }
+          });
+    }
+
+    /**
      * Allows us to perform recursive class lookups, if required.
      *
      * <p>Contains a special behavior to handle nested non-static classes - the default constructor
@@ -705,10 +966,15 @@ public final class Injector implements Closeable {
      * @param clazz to add
      * @param skipDuplicates marking whether we should tolerate duplicates to save execution time or
      *     throw an exception
+     * @param adjuster to tweak created instances after injection, or {@code null} if not needed
+     * @param <T> is the type of the class to parse
      * @throws IllegalArgumentException if non-tolerable duplicate was created or attempted to use
      *     {@link Collection} or {@link Map} for injection
      */
-    protected void parseClassForGraph(Class<?> clazz, boolean skipDuplicates) {
+    protected <T> void parseClassForGraph(
+        Class<T> clazz,
+        boolean skipDuplicates,
+        @Nullable BiConsumer<Injector, ? super T> adjuster) {
       final var classKey = new Key<>(clazz, getQualifierAnnotations(clazz.getAnnotations()));
 
       if (providers.containsKey(classKey)) {
@@ -719,80 +985,186 @@ public final class Injector implements Closeable {
         }
       }
 
-      final var node = createConstructsNode(clazz);
+      final var node = createConstructsNode(clazz, adjuster);
       providers.put(classKey, node);
       checkForCycle(classKey, node);
 
       for (Method providerMethod : getProviderMethods(clazz)) {
-        final var methodReturnType = providerMethod.getGenericReturnType();
-
-        if (methodReturnType instanceof ParameterizedType) {
-          throw new IllegalArgumentException(NO_WRAPPER_EXPECTED_TEMPLATE);
-        }
-
-        final var methodReturnClass = (Class<?>) methodReturnType;
-        final var methodAnnotations = getQualifierAnnotations(providerMethod.getAnnotations());
-        final var methodKey = new Key<>(methodReturnClass, methodAnnotations);
-        final var methodReturnTypeFields = getFields(methodReturnClass);
-
-        if (providers.containsKey(methodKey)) {
-          throw new IllegalArgumentException(String.format(DUPLICATE_VALUE_TEMPLATE, classKey));
-        }
-
-        final var methodParameters = getParameters(providerMethod);
-
-        Node<?> methodNode;
-        if (providerMethod.isAnnotationPresent(Singleton.class)
-            || methodReturnClass.isAnnotationPresent(Singleton.class)) {
-          methodNode =
-              new ProvidesSingleton<>(
-                  injectorReference,
-                  classKey,
-                  providerMethod,
-                  methodReturnClass,
-                  methodParameters,
-                  methodReturnTypeFields);
-        } else {
-          methodNode =
-              new ProvidesNew<>(
-                  injectorReference,
-                  classKey,
-                  providerMethod,
-                  methodReturnClass,
-                  methodParameters,
-                  methodReturnTypeFields);
-        }
-
-        providers.put(methodKey, methodNode);
-        checkForCycle(methodKey, methodNode);
+        parseProviderMethodForGraph(classKey, providerMethod);
       }
+    }
+
+    /**
+     * Parses a {@link Provides} method and adds its node to the dependency graph.
+     *
+     * @param classKey key of the factory/configuration class declaring the method
+     * @param providerMethod method to parse
+     * @throws IllegalArgumentException if provider method return type is unsupported or duplicates
+     *     an existing key
+     */
+    private void parseProviderMethodForGraph(Key<?> classKey, Method providerMethod) {
+      final var methodReturnClass = getPlainClass(providerMethod.getGenericReturnType());
+
+      if (Void.TYPE.equals(methodReturnClass)
+          || Void.class.equals(methodReturnClass)
+          || Provider.class.equals(methodReturnClass)
+          || Supplier.class.equals(methodReturnClass)) {
+        throw new IllegalArgumentException(NO_WRAPPER_EXPECTED_TEMPLATE);
+      }
+
+      final var methodAnnotations = getQualifierAnnotations(providerMethod.getAnnotations());
+      final var methodKey =
+          new Key<>(
+              methodReturnClass,
+              methodAnnotations.isEmpty()
+                  ? getQualifierAnnotations(methodReturnClass.getAnnotations())
+                  : methodAnnotations);
+      final var methodReturnTypeFields = getFields(methodReturnClass);
+
+      if (providers.containsKey(methodKey)) {
+        throw new IllegalArgumentException(String.format(DUPLICATE_VALUE_TEMPLATE, methodKey));
+      }
+
+      final var methodParameters = getParameters(providerMethod);
+
+      Node<?> methodNode;
+      if (providerMethod.isAnnotationPresent(Singleton.class)
+          || methodReturnClass.isAnnotationPresent(Singleton.class)) {
+        methodNode =
+            new ProvidesSingleton<>(
+                injectorReference,
+                classKey,
+                providerMethod,
+                methodReturnClass,
+                methodParameters,
+                methodReturnTypeFields);
+      } else {
+        methodNode =
+            new ProvidesNew<>(
+                injectorReference,
+                classKey,
+                providerMethod,
+                methodReturnClass,
+                methodParameters,
+                methodReturnTypeFields);
+      }
+
+      providers.put(methodKey, methodNode);
+      checkForCycle(methodKey, methodNode);
     }
 
     /**
      * Dismantles class definition to the {@link ConstructsNew} or {@link ConstructsSingleton} node.
      *
      * @param clazz to dismantle
+     * @param adjuster to tweak created instances after injection, or {@code null} if not needed
      * @return new node for the dependency graph
      * @param <T> is the type of the node
      */
-    protected <T> Node<T> createConstructsNode(Class<T> clazz) {
+    protected <T> Node<T> createConstructsNode(
+        Class<T> clazz, @Nullable BiConsumer<Injector, ? super T> adjuster) {
       final var constructor = getInjectableConstructor(clazz);
       final var constructorParameters = getParameters(constructor);
       final var classFields = getFields(clazz);
 
-      if (clazz.isAnnotationPresent(Singleton.class)) {
-        return new ConstructsSingleton<>(
-            injectorReference, constructor, constructorParameters, classFields);
-      } else {
-        return new ConstructsNew<>(
-            injectorReference, constructor, constructorParameters, classFields);
+      final var isSingleton = clazz.isAnnotationPresent(Singleton.class);
+      final Node<T> node =
+          isSingleton
+              ? new ConstructsSingleton<>(
+                  injectorReference, constructor, constructorParameters, classFields)
+              : new ConstructsNew<>(
+                  injectorReference, constructor, constructorParameters, classFields);
+
+      return adjuster == null
+          ? node
+          : new AdjustedNode<>(injectorReference, node, adjuster, isSingleton);
+    }
+
+    /**
+     * Checks that singleton-scoped nodes do not directly depend on non-singleton nodes.
+     *
+     * @throws IllegalArgumentException if captive dependency is found
+     */
+    private void checkForCaptiveDependencies() {
+      for (Map.Entry<Key<?>, Node<?>> entry : providers.entrySet()) {
+        if (!isSingletonScoped(entry.getValue())) {
+          continue;
+        }
+
+        for (Key<?> parentKey : entry.getValue().requiredParentKeys()) {
+          if (mustSkipCaptiveDependencyCheck(entry.getKey(), entry.getValue(), parentKey)) {
+            continue;
+          }
+
+          if (!isSingletonScoped(parentKey)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    CAPTIVE_DEPENDENCY_TEMPLATE,
+                    entry.getKey(),
+                    parentKey,
+                    parentKey,
+                    parentKey.type().getName(),
+                    parentKey.type().getName()));
+          }
+        }
       }
+    }
+
+    /**
+     * Determines whether a dependency edge should be ignored by captive dependency validation.
+     *
+     * @param ownerKey key of the node whose dependency is checked
+     * @param ownerNode node whose dependency is checked
+     * @param parentKey dependency key to evaluate
+     * @return {@code true} if validation must skip the edge
+     */
+    private boolean mustSkipCaptiveDependencyCheck(
+        Key<?> ownerKey, Node<?> ownerNode, Key<?> parentKey) {
+      if (isUnqualifiedInjectorKey(parentKey) || !providers.containsKey(parentKey)) {
+        return true;
+      }
+
+      if (ownerNode instanceof ProvidesNew<?>
+          && ((ProvidesNew<?>) ownerNode).getClassKey().equals(parentKey)) {
+        return true;
+      }
+
+      return isNestedNonStaticClass(ownerKey.type())
+          && parentKey.type().equals(ownerKey.type().getEnclosingClass());
+    }
+
+    /**
+     * Checks whether the node registered under the key is singleton-scoped.
+     *
+     * @param key to check
+     * @return {@code true} if the registered node is singleton-scoped
+     */
+    private boolean isSingletonScoped(Key<?> key) {
+      return isSingletonScoped(Objects.requireNonNull(providers.get(key)));
+    }
+
+    /**
+     * Checks whether the node is singleton-scoped.
+     *
+     * @param node to check
+     * @return {@code true} if the node is singleton-scoped
+     */
+    private boolean isSingletonScoped(Node<?> node) {
+      if (node instanceof RefersTo<?>) {
+        final var targetKey = node.parentKeys().iterator().next();
+        return isSingletonScoped(targetKey);
+      }
+
+      return node instanceof ConstructsSingleton<?>
+          || node instanceof ProvidesSingleton<?>
+          || node instanceof Value<?>
+          || (node instanceof AdjustedNode<?> && ((AdjustedNode<?>) node).singleton);
     }
 
     /**
      * Checks if there are any cycles in the dependency graph.
      *
-     * <p>Nested non-static classes have additional behavior when it comes to constructors where
+     * <p>Nested non-static classes have additional behavior when it comes to constructors where the
      * enclosing class is passed as a first parameter to the class constructor.
      *
      * <p>Here for cycle detection, we want to exclude any enclosing classes from the visited set -
@@ -808,7 +1180,7 @@ public final class Injector implements Closeable {
     /**
      * Checks recursively (BFS-like) if there are any cycles in the dependency graph.
      *
-     * <p>Nested non-static classes have additional behavior when it comes to constructors where
+     * <p>Nested non-static classes have additional behavior when it comes to constructors where the
      * enclosing class is passed as a first parameter to the class constructor.
      *
      * <p>Here for cycle detection, we want to exclude any enclosing classes from the visited set -
@@ -816,7 +1188,8 @@ public final class Injector implements Closeable {
      *
      * @param key to start check from
      * @param node which corresponds to the key
-     * @param visited set of nodes for validation
+     * @param visiting keys in the current traversal path
+     * @param processed keys already checked for cycles
      * @throws IllegalArgumentException if the cycle was found
      */
     private void checkForCycle(
@@ -833,12 +1206,7 @@ public final class Injector implements Closeable {
       final var isNestedNonStaticClass = isNestedNonStaticClass(key.type());
 
       for (Key<?> consumedKey : node.requiredParentKeys()) {
-        if (
-        // Skip nested node required classes
-        (isNestedNonStaticClass && consumedKey.type().equals(key.type().getEnclosingClass()))
-            // Skip method's enclosing class
-            || (node instanceof ProvidesNew
-                && ((ProvidesNew<?>) node).getClassKey().equals(consumedKey))) {
+        if (isNestedNonStaticClass && consumedKey.type().equals(key.type().getEnclosingClass())) {
           continue;
         }
 
@@ -906,8 +1274,8 @@ public final class Injector implements Closeable {
      * {@link Method}.
      *
      * @param executable to identify {@link Key} for
-     * @return a fixed size map of {@link Parameter} and their {@link Key} which declaration order
-     *     matches argument declaration order of the {@link Executable} parameters
+     * @return an immutable list of {@link ParameterInformation} whose declaration order matches
+     *     argument declaration order of the {@link Executable} parameters
      */
     protected static List<ParameterInformation> getParameters(Executable executable) {
       final var parameters = executable.getParameters();
@@ -955,7 +1323,7 @@ public final class Injector implements Closeable {
      * Identifies the key which must be used to fetch a value for the given {@link Field}.
      *
      * @param clazz to identify injectable {@link Field}s with their {@link Key}s
-     * @return a fixed size map of {@link Field} and their {@link Key}s
+     * @return an immutable list of {@link FieldInformation} for injectable fields
      */
     protected static List<FieldInformation> getFields(Class<?> clazz) {
       final var fields = new ArrayList<FieldInformation>();
@@ -965,6 +1333,10 @@ public final class Injector implements Closeable {
         for (Field field : current.getDeclaredFields()) {
           if (!field.isAnnotationPresent(Inject.class)) {
             continue;
+          }
+
+          if (Modifier.isStatic(field.getModifiers()) || Modifier.isFinal(field.getModifiers())) {
+            throw new IllegalArgumentException("Injected field must not be static or final");
           }
 
           final var fieldType = field.getGenericType();
@@ -992,10 +1364,17 @@ public final class Injector implements Closeable {
      */
     protected static Set<Method> getProviderMethods(Class<?> clazz) {
       final var methods = new HashSet<Method>();
+      final var descendantMethods = new ArrayList<Method>();
 
       Class<?> current = clazz;
       while (!current.equals(Object.class)) {
         for (Method method : current.getDeclaredMethods()) {
+          if (descendantMethods.stream().anyMatch(descendant -> overrides(descendant, method))) {
+            continue;
+          }
+
+          descendantMethods.add(method);
+
           if (method.isAnnotationPresent(Provides.class)) {
             methods.add(method);
           }
@@ -1008,6 +1387,72 @@ public final class Injector implements Closeable {
     }
 
     /**
+     * Checks whether one method overrides another.
+     *
+     * @param descendant possible overriding method
+     * @param ancestor possible overridden method
+     * @return {@code true} if descendant overrides ancestor
+     */
+    private static boolean overrides(Method descendant, Method ancestor) {
+      if (!ancestor.getDeclaringClass().isAssignableFrom(descendant.getDeclaringClass())) {
+        return false;
+      }
+
+      final int descendantModifiers = descendant.getModifiers();
+      final int ancestorModifiers = ancestor.getModifiers();
+      if (Modifier.isPrivate(descendantModifiers)
+          || Modifier.isPrivate(ancestorModifiers)
+          || Modifier.isStatic(descendantModifiers)
+          || Modifier.isStatic(ancestorModifiers)
+          || Modifier.isFinal(ancestorModifiers)) {
+        return false;
+      }
+
+      if (!methodSignature(descendant).equals(methodSignature(ancestor))) {
+        return false;
+      }
+
+      return Modifier.isPublic(ancestorModifiers)
+          || Modifier.isProtected(ancestorModifiers)
+          || descendant
+              .getDeclaringClass()
+              .getPackageName()
+              .equals(ancestor.getDeclaringClass().getPackageName());
+    }
+
+    /**
+     * Creates method signature string from method name and parameter types.
+     *
+     * @param method to create signature for
+     * @return method signature string
+     */
+    private static String methodSignature(Method method) {
+      return method.getName() + List.of(method.getParameterTypes());
+    }
+
+    /**
+     * Fetch a non-generic class from a {@link Type}.
+     *
+     * @param type to analyze
+     * @return plain class represented by the type
+     * @throws IllegalArgumentException if the type cannot be represented by a plain class key
+     */
+    protected static Class<?> getPlainClass(Type type) {
+      if (type instanceof Class<?>) {
+        return (Class<?>) type;
+      }
+
+      if (type instanceof ParameterizedType
+          || type instanceof TypeVariable<?>
+          || type instanceof WildcardType
+          || type instanceof GenericArrayType) {
+        throw new IllegalArgumentException(NO_WRAPPER_EXPECTED_TEMPLATE);
+      }
+
+      throw new IllegalArgumentException(NO_WRAPPER_EXPECTED_TEMPLATE);
+    }
+
+    /**
      * Fetch the class of the value type and its generic wrapper class from the {@link Type}.
      *
      * <p>Used to identify {@link Provider} and {@link Supplier} usage.
@@ -1016,14 +1461,13 @@ public final class Injector implements Closeable {
      * @return a {@link Map.Entry} where the key is the type of the value and value is the type of
      *     the wrapper
      */
-    protected static Map.Entry<Class<?>, Class<?>> getGenericValueAndWrapper(Type type) {
+    protected static Map.Entry<Class<?>, @Nullable Class<?>> getGenericValueAndWrapper(Type type) {
       Class<?> wrapperClass;
       Class<?> valueClass;
 
       if (type instanceof ParameterizedType) {
         final var parameterizedType = (ParameterizedType) type;
-
-        wrapperClass = (Class<?>) parameterizedType.getRawType();
+        wrapperClass = getPlainClass(parameterizedType.getRawType());
 
         if (ReflectionNode.isNotSupportedWrapperClass(wrapperClass)) {
           throw new IllegalArgumentException(
@@ -1040,10 +1484,14 @@ public final class Injector implements Closeable {
                   actualTypeArgument.getTypeName()));
         }
 
-        valueClass = (Class<?>) actualTypeArgument;
+        valueClass = getPlainClass(actualTypeArgument);
       } else {
-        valueClass = (Class<?>) type;
+        valueClass = getPlainClass(type);
         wrapperClass = null;
+
+        if (Provider.class.equals(valueClass) || Supplier.class.equals(valueClass)) {
+          throw new IllegalArgumentException(NO_WRAPPER_EXPECTED_TEMPLATE);
+        }
       }
 
       return new AbstractMap.SimpleImmutableEntry<>(valueClass, wrapperClass);

--- a/src/main/java/io/github/suppierk/inject/Injector.java
+++ b/src/main/java/io/github/suppierk/inject/Injector.java
@@ -54,6 +54,7 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -1408,7 +1409,8 @@ public final class Injector implements Closeable {
         return false;
       }
 
-      if (!methodSignature(descendant).equals(methodSignature(ancestor))) {
+      if (!descendant.getName().equals(ancestor.getName())
+          || !Arrays.equals(descendant.getParameterTypes(), ancestor.getParameterTypes())) {
         return false;
       }
 
@@ -1418,16 +1420,6 @@ public final class Injector implements Closeable {
               .getDeclaringClass()
               .getPackageName()
               .equals(ancestor.getDeclaringClass().getPackageName());
-    }
-
-    /**
-     * Creates method signature string from method name and parameter types.
-     *
-     * @param method to create signature for
-     * @return method signature string
-     */
-    private static String methodSignature(Method method) {
-      return method.getName() + List.of(method.getParameterTypes());
     }
 
     /**

--- a/src/main/java/io/github/suppierk/inject/InjectorReference.java
+++ b/src/main/java/io/github/suppierk/inject/InjectorReference.java
@@ -25,6 +25,7 @@ package io.github.suppierk.inject;
 
 import io.github.suppierk.inject.graph.Node;
 import java.util.concurrent.atomic.AtomicReference;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Value class which holds a reference to a particular instance of {@link Injector}.
@@ -37,7 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 @SuppressWarnings({"javaarchitecture:S7091", "javaarchitecture:S7027"})
 public final class InjectorReference {
-  private final AtomicReference<Injector> reference;
+  private final AtomicReference<@Nullable Injector> reference;
 
   /** Default constructor. */
   public InjectorReference() {
@@ -48,9 +49,9 @@ public final class InjectorReference {
    * Sets the reference to the injector using atomic CAS.
    *
    * @param injector to set
-   * @throws IllegalArgumentException if {@link Injector} instance to set is {@code null}
+   * @throws IllegalStateException if {@link Injector} instance to set is {@code null}
    */
-  public void set(Injector injector) {
+  public void set(@Nullable Injector injector) {
     if (injector == null) {
       throw new IllegalStateException("Injector to set is null");
     }
@@ -59,19 +60,30 @@ public final class InjectorReference {
   }
 
   /**
+   * Retrieves the referenced {@link Injector}.
+   *
+   * @return referenced injector
+   * @throws IllegalStateException if {@link #set(Injector)} has not been called yet
+   */
+  public Injector get() {
+    final var injector = reference.get();
+
+    if (injector == null) {
+      throw new IllegalStateException("No Injector available");
+    }
+
+    return injector;
+  }
+
+  /**
    * Retrieves dependency graph node by delegating a call to {@link Injector#getNode(Key)}.
    *
    * @param key of the dependency to fetch
    * @return a respective dependency graph node which instantiates this particular dependency
    * @param <T> is the type of the dependency
-   * @throws IllegalStateException because by the time this is called we expect {@link
-   *     #set(Injector)} to be called and reference to be set
+   * @throws IllegalStateException if {@link #set(Injector)} has not been called yet
    */
   public <T> Node<T> getNode(Key<T> key) {
-    if (reference.get() == null) {
-      throw new IllegalStateException("No Injector available");
-    }
-
-    return reference.get().getNode(key);
+    return get().getNode(key);
   }
 }

--- a/src/main/java/io/github/suppierk/inject/Key.java
+++ b/src/main/java/io/github/suppierk/inject/Key.java
@@ -26,9 +26,11 @@ package io.github.suppierk.inject;
 import io.github.suppierk.utils.ConsoleConstants;
 import jakarta.inject.Qualifier;
 import java.lang.annotation.Annotation;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a map key for the qualified object lookup.
@@ -36,10 +38,15 @@ import java.util.stream.Collectors;
  * @param <T> is the type of the object
  */
 public final class Key<T> {
+  private static final Comparator<Annotation> ANNOTATION_COMPARATOR =
+      Comparator.comparing((Annotation annotation) -> annotation.annotationType().getName())
+          .thenComparing(Annotation::toString);
+
   private final Class<T> type;
   private final Set<Annotation> annotations;
+  private final int hashCode;
 
-  public Key(Class<T> type, Set<Annotation> annotations) {
+  public Key(@Nullable Class<T> type, @Nullable Set<@Nullable Annotation> annotations) {
     if (type == null) {
       throw new IllegalArgumentException("Type is null");
     } else {
@@ -53,6 +60,10 @@ public final class Key<T> {
           annotations.stream()
               .map(
                   annotation -> {
+                    if (annotation == null) {
+                      throw new IllegalArgumentException("Annotation is null");
+                    }
+
                     if (!annotation.annotationType().isAnnotationPresent(Qualifier.class)) {
                       throw new IllegalArgumentException(
                           "Annotation @"
@@ -64,6 +75,8 @@ public final class Key<T> {
                   })
               .collect(Collectors.toUnmodifiableSet());
     }
+
+    this.hashCode = calculateHashCode();
   }
 
   public Class<T> type() {
@@ -75,7 +88,7 @@ public final class Key<T> {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof Key)) {
       return false;
     }
@@ -86,7 +99,16 @@ public final class Key<T> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, annotations);
+    return hashCode;
+  }
+
+  /**
+   * Used by EqualsVerify test
+   *
+   * @return pre-calculated hash code
+   */
+  private int calculateHashCode() {
+    return 31 * type.hashCode() + annotations.hashCode();
   }
 
   @Override
@@ -127,6 +149,7 @@ public final class Key<T> {
             : String.format(
                 "%n%s",
                 annotations().stream()
+                    .sorted(ANNOTATION_COMPARATOR)
                     .map(
                         annotation ->
                             String.format(

--- a/src/main/java/io/github/suppierk/inject/ParameterInformation.java
+++ b/src/main/java/io/github/suppierk/inject/ParameterInformation.java
@@ -26,14 +26,16 @@ package io.github.suppierk.inject;
 import java.lang.reflect.Parameter;
 import java.util.Objects;
 import java.util.StringJoiner;
+import org.jspecify.annotations.Nullable;
 
 /** Defines base information about specific class method parameter. */
 public final class ParameterInformation {
   private final Parameter parameter;
   private final Key<?> key;
-  private final Class<?> wrapper;
+  private final @Nullable Class<?> wrapper;
 
-  public ParameterInformation(Parameter parameter, Key<?> key, Class<?> wrapper) {
+  public ParameterInformation(
+      @Nullable Parameter parameter, @Nullable Key<?> key, @Nullable Class<?> wrapper) {
     if (parameter == null) {
       throw new IllegalArgumentException("Parameter is null");
     }
@@ -57,12 +59,12 @@ public final class ParameterInformation {
   }
 
   @SuppressWarnings("squid:S1452")
-  public Class<?> getWrapper() {
+  public @Nullable Class<?> getWrapper() {
     return wrapper;
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof ParameterInformation)) return false;
     ParameterInformation that = (ParameterInformation) o;
     return Objects.equals(parameter, that.parameter)

--- a/src/main/java/io/github/suppierk/inject/graph/ConstructsNew.java
+++ b/src/main/java/io/github/suppierk/inject/graph/ConstructsNew.java
@@ -29,8 +29,10 @@ import io.github.suppierk.inject.ParameterInformation;
 import io.github.suppierk.utils.ConsoleConstants;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a node which instantiates a new class instance by calling its constructor.
@@ -38,6 +40,11 @@ import java.util.stream.Collectors;
  * @param <T> is the type of the instance this node refers to
  */
 public class ConstructsNew<T> extends ReflectionNode<T> {
+  private static final Comparator<FieldInformation> FIELD_INFORMATION_COMPARATOR =
+      Comparator.comparing((FieldInformation info) -> info.getQualifierKey().type().getName())
+          .thenComparing(info -> info.getField().getDeclaringClass().getName())
+          .thenComparing(info -> info.getField().getName());
+
   protected final Constructor<T> constructor;
 
   /**
@@ -50,10 +57,10 @@ public class ConstructsNew<T> extends ReflectionNode<T> {
    * @throws IllegalArgumentException if constructor is {@code null}
    */
   public ConstructsNew(
-      InjectorReference injectorReference,
-      Constructor<T> constructor,
-      List<ParameterInformation> parametersInformation,
-      List<FieldInformation> fieldsInformation) {
+      @Nullable InjectorReference injectorReference,
+      @Nullable Constructor<T> constructor,
+      @Nullable List<ParameterInformation> parametersInformation,
+      @Nullable List<FieldInformation> fieldsInformation) {
     super(injectorReference, parametersInformation, fieldsInformation);
 
     if (constructor == null) {
@@ -96,7 +103,7 @@ public class ConstructsNew<T> extends ReflectionNode<T> {
 
   /** Constructor equality leverages parameters, which we already check in superclass. */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof ConstructsNew)) return false;
     return super.equals(o);
   }
@@ -155,6 +162,7 @@ public class ConstructsNew<T> extends ReflectionNode<T> {
                 : String.format(
                     "%n%s",
                     fieldsInformation().stream()
+                        .sorted(FIELD_INFORMATION_COMPARATOR)
                         .map(
                             info -> info.getQualifierKey().toYamlString(true, indentationLevel + 2))
                         .collect(Collectors.joining(String.format("%n"))))));

--- a/src/main/java/io/github/suppierk/inject/graph/ConstructsSingleton.java
+++ b/src/main/java/io/github/suppierk/inject/graph/ConstructsSingleton.java
@@ -30,6 +30,7 @@ import io.github.suppierk.utils.Memoized;
 import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a node which calls {@link ConstructsNew} logic to instantiate the value and stores
@@ -53,14 +54,14 @@ public final class ConstructsSingleton<T> extends ConstructsNew<T> {
    * @throws IllegalArgumentException if constructor is {@code null}
    */
   public ConstructsSingleton(
-      InjectorReference injectorReference,
-      Constructor<T> constructor,
-      List<ParameterInformation> parametersInformation,
-      List<FieldInformation> fieldsInformation) {
+      @Nullable InjectorReference injectorReference,
+      @Nullable Constructor<T> constructor,
+      @Nullable List<ParameterInformation> parametersInformation,
+      @Nullable List<FieldInformation> fieldsInformation) {
     this(
         injectorReference,
         constructor,
-        createOnCloseConsumer(constructor.getDeclaringClass()),
+        createOnCloseConsumer(declaringClass(constructor)),
         parametersInformation,
         fieldsInformation);
   }
@@ -76,14 +77,22 @@ public final class ConstructsSingleton<T> extends ConstructsNew<T> {
    * @throws IllegalArgumentException if constructor is {@code null}
    */
   private ConstructsSingleton(
-      InjectorReference injectorReference,
-      Constructor<T> constructor,
+      @Nullable InjectorReference injectorReference,
+      @Nullable Constructor<T> constructor,
       Consumer<T> onCloseConsumer,
-      List<ParameterInformation> parametersInformation,
-      List<FieldInformation> fieldsInformation) {
+      @Nullable List<ParameterInformation> parametersInformation,
+      @Nullable List<FieldInformation> fieldsInformation) {
     super(injectorReference, constructor, parametersInformation, fieldsInformation);
     this.memoized = Memoized.memoizedProvider(super::get);
     this.onCloseConsumer = onCloseConsumer;
+  }
+
+  private static <T> Class<T> declaringClass(@Nullable Constructor<T> constructor) {
+    if (constructor == null) {
+      throw new IllegalArgumentException("Constructor is null");
+    }
+
+    return constructor.getDeclaringClass();
   }
 
   /** {@inheritDoc} */
@@ -107,7 +116,7 @@ public final class ConstructsSingleton<T> extends ConstructsNew<T> {
 
   /** {@inheritDoc} */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof ConstructsSingleton)) return false;
     return super.equals(o);
   }

--- a/src/main/java/io/github/suppierk/inject/graph/Node.java
+++ b/src/main/java/io/github/suppierk/inject/graph/Node.java
@@ -29,10 +29,10 @@ import io.github.suppierk.inject.Key;
 import jakarta.inject.Provider;
 import java.io.Closeable;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a baseline structure for the dependency graph node.
@@ -51,7 +51,7 @@ public abstract class Node<T> implements Provider<T>, Supplier<T>, Closeable {
    * @param injectorReference for dependency lookups
    * @param parentKeys for integrity and cycle check lookups
    */
-  protected Node(InjectorReference injectorReference, Set<Key<?>> parentKeys) {
+  protected Node(@Nullable InjectorReference injectorReference, @Nullable Set<Key<?>> parentKeys) {
     if (injectorReference == null) {
       throw new IllegalArgumentException("Injector reference is null");
     }
@@ -96,7 +96,7 @@ public abstract class Node<T> implements Provider<T>, Supplier<T>, Closeable {
 
   /** {@inheritDoc} */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof Node)) return false;
     Node<?> that = (Node<?>) o;
     return Objects.equals(parentKeys, that.parentKeys);
@@ -109,37 +109,27 @@ public abstract class Node<T> implements Provider<T>, Supplier<T>, Closeable {
   }
 
   /**
-   * Similar to {@link Optional#empty()} but for {@link Consumer}.
-   *
-   * @return empty {@link Consumer}
-   * @param <C> is the type of the consumed object
-   */
-  protected static <C> Consumer<C> emptyConsumer() {
-    @SuppressWarnings("unchecked")
-    Consumer<C> emptyConsumer = (Consumer<C>) EMPTY_CONSUMER;
-    return emptyConsumer;
-  }
-
-  /**
    * Identify default behavior to clean up resources for the given class.
    *
    * <p><b>NOTE</b>: {@link Closeable} extends {@link AutoCloseable}.
    *
    * @param clazz to identify behavior for
-   * @return {@link Consumer} to handle resource clean up
+   * @return {@link Consumer} to handle resource cleanup
    * @param <T> is the type of the potentially {@link AutoCloseable} resource
    */
-  protected static <T> Consumer<T> createOnCloseConsumer(Class<T> clazz) {
-    if (AutoCloseable.class.isAssignableFrom(clazz)) {
-      return resource -> {
+  protected static <T> Consumer<T> createOnCloseConsumer(@Nullable Class<T> clazz) {
+    if (clazz == null) {
+      throw new IllegalArgumentException("Class is null");
+    }
+
+    return resource -> {
+      if (resource instanceof AutoCloseable autoCloseable) {
         try {
-          ((AutoCloseable) resource).close();
+          autoCloseable.close();
         } catch (Exception e) {
           throw new IllegalStateException("Could not close resource", e);
         }
-      };
-    }
-
-    return emptyConsumer();
+      }
+    };
   }
 }

--- a/src/main/java/io/github/suppierk/inject/graph/ProvidesNew.java
+++ b/src/main/java/io/github/suppierk/inject/graph/ProvidesNew.java
@@ -30,9 +30,11 @@ import io.github.suppierk.inject.ParameterInformation;
 import io.github.suppierk.utils.ConsoleConstants;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a node which instantiates a new class instance by calling a method of the existing
@@ -41,6 +43,11 @@ import java.util.stream.Collectors;
  * @param <T> is the type of the instance this node refers to
  */
 public class ProvidesNew<T> extends ReflectionNode<T> {
+  private static final Comparator<FieldInformation> FIELD_INFORMATION_COMPARATOR =
+      Comparator.comparing((FieldInformation info) -> info.getQualifierKey().type().getName())
+          .thenComparing(info -> info.getField().getDeclaringClass().getName())
+          .thenComparing(info -> info.getField().getName());
+
   protected final Key<?> classKey;
   protected final Method method;
   protected final Class<T> methodReturnClass;
@@ -57,12 +64,28 @@ public class ProvidesNew<T> extends ReflectionNode<T> {
    * @throws IllegalArgumentException if class key or method are {@code null}
    */
   public ProvidesNew(
-      InjectorReference injectorReference,
+      @Nullable InjectorReference injectorReference,
+      @Nullable Key<?> classKey,
+      @Nullable Method method,
+      @Nullable Class<T> methodReturnClass,
+      @Nullable List<ParameterInformation> parametersInformation,
+      @Nullable List<FieldInformation> fieldsInformation) {
+    this(
+        requireClassKey(classKey),
+        injectorReference,
+        method,
+        methodReturnClass,
+        parametersInformation,
+        fieldsInformation);
+  }
+
+  private ProvidesNew(
       Key<?> classKey,
-      Method method,
-      Class<T> methodReturnClass,
-      List<ParameterInformation> parametersInformation,
-      List<FieldInformation> fieldsInformation) {
+      @Nullable InjectorReference injectorReference,
+      @Nullable Method method,
+      @Nullable Class<T> methodReturnClass,
+      @Nullable List<ParameterInformation> parametersInformation,
+      @Nullable List<FieldInformation> fieldsInformation) {
     super(injectorReference, parametersInformation, fieldsInformation, classKey);
 
     if (method == null) {
@@ -79,6 +102,15 @@ public class ProvidesNew<T> extends ReflectionNode<T> {
   }
 
   @SuppressWarnings("squid:S1452")
+  private static Key<?> requireClassKey(@Nullable Key<?> classKey) {
+    if (classKey == null) {
+      throw new IllegalArgumentException("Class key is null");
+    }
+
+    return classKey;
+  }
+
+  @SuppressWarnings("squid:S1452")
   public Key<?> getClassKey() {
     return classKey;
   }
@@ -91,7 +123,12 @@ public class ProvidesNew<T> extends ReflectionNode<T> {
 
     try {
       if (method.trySetAccessible()) {
-        return injectFields((T) method.invoke(objectInstance, createArguments()));
+        final var provided = (T) method.invoke(objectInstance, createArguments());
+        if (provided == null) {
+          throw new IllegalArgumentException("Provider returned null");
+        }
+
+        return injectFields(provided);
       } else {
         throw new IllegalAccessException(
             String.format(
@@ -124,7 +161,7 @@ public class ProvidesNew<T> extends ReflectionNode<T> {
 
   /** {@inheritDoc} */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof ProvidesNew)) return false;
     if (!super.equals(o)) return false;
     ProvidesNew<?> that = (ProvidesNew<?>) o;
@@ -190,6 +227,7 @@ public class ProvidesNew<T> extends ReflectionNode<T> {
                 : String.format(
                     "%n%s",
                     fieldsInformation().stream()
+                        .sorted(FIELD_INFORMATION_COMPARATOR)
                         .map(
                             info -> info.getQualifierKey().toYamlString(true, indentationLevel + 2))
                         .collect(Collectors.joining(String.format("%n"))))));

--- a/src/main/java/io/github/suppierk/inject/graph/ProvidesSingleton.java
+++ b/src/main/java/io/github/suppierk/inject/graph/ProvidesSingleton.java
@@ -31,6 +31,7 @@ import io.github.suppierk.utils.Memoized;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a node which calls {@link ProvidesNew} logic to instantiate the value and stores
@@ -56,12 +57,12 @@ public final class ProvidesSingleton<T> extends ProvidesNew<T> {
    * @throws IllegalArgumentException if class key or method are {@code null}
    */
   public ProvidesSingleton(
-      InjectorReference injectorReference,
-      Key<?> classKey,
-      Method method,
-      Class<T> methodReturnClass,
-      List<ParameterInformation> parametersInformation,
-      List<FieldInformation> fieldsInformation) {
+      @Nullable InjectorReference injectorReference,
+      @Nullable Key<?> classKey,
+      @Nullable Method method,
+      @Nullable Class<T> methodReturnClass,
+      @Nullable List<ParameterInformation> parametersInformation,
+      @Nullable List<FieldInformation> fieldsInformation) {
     this(
         injectorReference,
         classKey,
@@ -83,13 +84,13 @@ public final class ProvidesSingleton<T> extends ProvidesNew<T> {
    * @throws IllegalArgumentException if class key or method are {@code null}
    */
   private ProvidesSingleton(
-      InjectorReference injectorReference,
-      Key<?> classKey,
-      Method method,
-      Class<T> methodReturnClass,
+      @Nullable InjectorReference injectorReference,
+      @Nullable Key<?> classKey,
+      @Nullable Method method,
+      @Nullable Class<T> methodReturnClass,
       Consumer<T> onCloseConsumer,
-      List<ParameterInformation> parametersInformation,
-      List<FieldInformation> fieldsInformation) {
+      @Nullable List<ParameterInformation> parametersInformation,
+      @Nullable List<FieldInformation> fieldsInformation) {
     super(
         injectorReference,
         classKey,
@@ -128,7 +129,7 @@ public final class ProvidesSingleton<T> extends ProvidesNew<T> {
 
   /** {@inheritDoc} */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof ProvidesSingleton)) return false;
     return super.equals(o);
   }

--- a/src/main/java/io/github/suppierk/inject/graph/RefersTo.java
+++ b/src/main/java/io/github/suppierk/inject/graph/RefersTo.java
@@ -27,6 +27,7 @@ import io.github.suppierk.inject.InjectorReference;
 import io.github.suppierk.inject.Key;
 import io.github.suppierk.utils.ConsoleConstants;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a node used for performing replacement operations.
@@ -46,7 +47,8 @@ public final class RefersTo<T> extends Node<T> {
    * @param injectorReference for dependency lookups
    * @param parentKey for integrity and cycle check lookups
    */
-  public RefersTo(InjectorReference injectorReference, Key<?> parentKey) {
+  @SuppressWarnings("squid:S6416")
+  public RefersTo(@Nullable InjectorReference injectorReference, @Nullable Key<?> parentKey) {
     super(injectorReference, singleton(parentKey));
   }
 
@@ -77,7 +79,7 @@ public final class RefersTo<T> extends Node<T> {
 
   /** {@inheritDoc} */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof RefersTo)) return false;
     return super.equals(o);
   }
@@ -110,7 +112,7 @@ public final class RefersTo<T> extends Node<T> {
    * @return a set consisting of a single element
    */
   @SuppressWarnings("squid:S1452")
-  private static Set<Key<?>> singleton(Key<?> key) {
+  private static Set<Key<?>> singleton(@Nullable Key<?> key) {
     if (key == null) {
       throw new IllegalArgumentException("Key is null");
     }

--- a/src/main/java/io/github/suppierk/inject/graph/ReflectionNode.java
+++ b/src/main/java/io/github/suppierk/inject/graph/ReflectionNode.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a baseline structure for the dependency graph nodes which can produce new object
@@ -55,17 +56,20 @@ public abstract class ReflectionNode<T> extends Node<T> {
    * @param extraParentKeys this node depends upon
    */
   protected ReflectionNode(
-      InjectorReference injectorReference,
-      List<ParameterInformation> parametersInformation,
-      List<FieldInformation> fieldsInformation,
-      Key<?>... extraParentKeys) {
+      @Nullable InjectorReference injectorReference,
+      @Nullable List<ParameterInformation> parametersInformation,
+      @Nullable List<FieldInformation> fieldsInformation,
+      Key<?> @Nullable ... extraParentKeys) {
     super(
         injectorReference,
         gatherParentKeys(parametersInformation, fieldsInformation, extraParentKeys));
+    final var checkedParametersInformation = Objects.requireNonNull(parametersInformation);
+    final var checkedFieldsInformation = Objects.requireNonNull(fieldsInformation);
     this.requiredParentKeys =
-        gatherRequiredParentKeys(parametersInformation, fieldsInformation, extraParentKeys);
-    this.parametersInformation = List.copyOf(parametersInformation);
-    this.fieldsInformation = List.copyOf(fieldsInformation);
+        gatherRequiredParentKeys(
+            checkedParametersInformation, checkedFieldsInformation, extraParentKeys);
+    this.parametersInformation = List.copyOf(checkedParametersInformation);
+    this.fieldsInformation = List.copyOf(checkedFieldsInformation);
   }
 
   public List<ParameterInformation> parametersInformation() {
@@ -137,7 +141,7 @@ public abstract class ReflectionNode<T> extends Node<T> {
 
   /** {@inheritDoc} */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof ReflectionNode)) return false;
     if (!super.equals(o)) return false;
     ReflectionNode<?> that = (ReflectionNode<?>) o;
@@ -162,9 +166,9 @@ public abstract class ReflectionNode<T> extends Node<T> {
    * @return an immutable set, truncated to the number of its elements
    */
   private static Set<Key<?>> gatherParentKeys(
-      List<ParameterInformation> parametersInformation,
-      List<FieldInformation> fieldsInformation,
-      Key<?>... extraParentKeys) {
+      @Nullable List<ParameterInformation> parametersInformation,
+      @Nullable List<FieldInformation> fieldsInformation,
+      Key<?> @Nullable ... extraParentKeys) {
     if (parametersInformation == null) {
       throw new IllegalArgumentException("parametersInformation is null");
     }
@@ -208,7 +212,7 @@ public abstract class ReflectionNode<T> extends Node<T> {
   private static Set<Key<?>> gatherRequiredParentKeys(
       List<ParameterInformation> parametersInformation,
       List<FieldInformation> fieldsInformation,
-      Key<?>... extraParentKeys) {
+      Key<?> @Nullable ... extraParentKeys) {
     final var result = new HashSet<Key<?>>(parametersInformation.size() + fieldsInformation.size());
 
     for (ParameterInformation parameterInformation : parametersInformation) {
@@ -236,7 +240,7 @@ public abstract class ReflectionNode<T> extends Node<T> {
    * @param clazz to check
    * @return {@code true}, if the {@link Class} is either {@link Provider} or {@link Supplier}
    */
-  public static boolean isNotSupportedWrapperClass(Class<?> clazz) {
+  public static boolean isNotSupportedWrapperClass(@Nullable Class<?> clazz) {
     return !Provider.class.equals(clazz) && !Supplier.class.equals(clazz);
   }
 }

--- a/src/main/java/io/github/suppierk/inject/graph/ReflectionNode.java
+++ b/src/main/java/io/github/suppierk/inject/graph/ReflectionNode.java
@@ -118,6 +118,10 @@ public abstract class ReflectionNode<T> extends Node<T> {
    */
   @SuppressWarnings("squid:S3011")
   protected T injectFields(T instance) throws IllegalAccessException {
+    if (fieldsInformation().isEmpty()) {
+      return instance;
+    }
+
     for (FieldInformation fieldInformation : fieldsInformation()) {
       if (fieldInformation.getField().trySetAccessible()) {
         final var currentFieldNode =

--- a/src/main/java/io/github/suppierk/inject/graph/Value.java
+++ b/src/main/java/io/github/suppierk/inject/graph/Value.java
@@ -28,6 +28,7 @@ import io.github.suppierk.utils.ConsoleConstants;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines dependency node with already instantiated value.
@@ -45,8 +46,16 @@ public final class Value<T> extends Node<T> {
    * @param instance to set
    * @throws IllegalArgumentException if the value is {@code null}
    */
-  public Value(InjectorReference injectorReference, T instance) {
-    this(injectorReference, instance, instanceOnCloseConsumer(instance));
+  @SuppressWarnings("squid:S6416")
+  public Value(@Nullable InjectorReference injectorReference, @Nullable T instance) {
+    super(injectorReference, Set.of());
+
+    if (instance == null) {
+      throw new IllegalArgumentException("Value is null");
+    }
+
+    this.instance = instance;
+    this.onCloseConsumer = instanceOnCloseConsumer(instance);
   }
 
   /**
@@ -57,7 +66,9 @@ public final class Value<T> extends Node<T> {
    * @param onCloseConsumer to clean yp resources
    * @throws IllegalArgumentException if the value is {@code null}
    */
-  private Value(InjectorReference injectorReference, T instance, Consumer<T> onCloseConsumer) {
+  @SuppressWarnings("squid:S6416")
+  private Value(
+      @Nullable InjectorReference injectorReference, T instance, Consumer<T> onCloseConsumer) {
     super(injectorReference, Set.of());
     this.instance = instance;
     this.onCloseConsumer = onCloseConsumer;
@@ -83,7 +94,7 @@ public final class Value<T> extends Node<T> {
 
   /** {@inheritDoc} */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof Value)) return false;
     Value<?> value = (Value<?>) o;
     return Objects.equals(this.instance, value.instance);
@@ -121,10 +132,6 @@ public final class Value<T> extends Node<T> {
    * @throws IllegalArgumentException if the value is {@code null}
    */
   private static <C> Consumer<C> instanceOnCloseConsumer(C instance) {
-    if (instance == null) {
-      throw new IllegalArgumentException("Value is null");
-    }
-
     @SuppressWarnings("unchecked")
     final Class<C> instanceClass = (Class<C>) instance.getClass();
     return createOnCloseConsumer(instanceClass);

--- a/src/main/java/io/github/suppierk/inject/graph/package-info.java
+++ b/src/main/java/io/github/suppierk/inject/graph/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.github.suppierk.inject.graph;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/io/github/suppierk/inject/package-info.java
+++ b/src/main/java/io/github/suppierk/inject/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.github.suppierk.inject;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/io/github/suppierk/inject/query/AnnotationPredicate.java
+++ b/src/main/java/io/github/suppierk/inject/query/AnnotationPredicate.java
@@ -26,6 +26,7 @@ package io.github.suppierk.inject.query;
 import java.lang.annotation.Annotation;
 import java.util.Objects;
 import java.util.function.Predicate;
+import org.jspecify.annotations.Nullable;
 
 /** Predicate to allow searching for a specific annotation with specific member values. */
 public final class AnnotationPredicate<T extends Annotation> implements Predicate<Annotation> {
@@ -46,7 +47,7 @@ public final class AnnotationPredicate<T extends Annotation> implements Predicat
   /** {@inheritDoc} */
   @Override
   @SuppressWarnings("unchecked")
-  public boolean test(Annotation annotation) {
+  public boolean test(@Nullable Annotation annotation) {
     return annotation != null
         && annotationClass.equals(annotation.annotationType())
         && annotationMembersPredicate.test((T) annotation);
@@ -54,7 +55,7 @@ public final class AnnotationPredicate<T extends Annotation> implements Predicat
 
   /** {@inheritDoc} */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof AnnotationPredicate)) return false;
     AnnotationPredicate<?> that = (AnnotationPredicate<?>) o;
     return Objects.equals(annotationClass, that.annotationClass)
@@ -94,7 +95,8 @@ public final class AnnotationPredicate<T extends Annotation> implements Predicat
      * @return next step of the fluent builder
      * @throws IllegalArgumentException if class is {@code null}
      */
-    public <T extends Annotation> AnnotationMembersPredicate<T> match(Class<T> annotationClass) {
+    public <T extends Annotation> AnnotationMembersPredicate<T> match(
+        @Nullable Class<T> annotationClass) {
       if (annotationClass == null) {
         throw new IllegalArgumentException("annotationClass cannot be null");
       }
@@ -113,7 +115,11 @@ public final class AnnotationPredicate<T extends Annotation> implements Predicat
      *
      * @param annotationClass to match against
      */
-    public AnnotationMembersPredicate(Class<T> annotationClass) {
+    public AnnotationMembersPredicate(@Nullable Class<T> annotationClass) {
+      if (annotationClass == null) {
+        throw new IllegalArgumentException("annotationClass cannot be null");
+      }
+
       this.annotationClass = annotationClass;
       this.membersPredicate = t -> true;
     }
@@ -125,7 +131,7 @@ public final class AnnotationPredicate<T extends Annotation> implements Predicat
      * @return this builder
      * @throws IllegalArgumentException if predicate is {@code null}
      */
-    public AnnotationMembersPredicate<T> where(Predicate<T> membersPredicate) {
+    public AnnotationMembersPredicate<T> where(@Nullable Predicate<T> membersPredicate) {
       if (membersPredicate == null) {
         throw new IllegalArgumentException("membersPredicate cannot be null");
       }

--- a/src/main/java/io/github/suppierk/inject/query/KeyAnnotationsPredicate.java
+++ b/src/main/java/io/github/suppierk/inject/query/KeyAnnotationsPredicate.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Predicate to allow searching for a specific key in {@link io.github.suppierk.inject.Injector}.
@@ -56,7 +57,7 @@ public final class KeyAnnotationsPredicate implements Predicate<Key<?>> {
 
   /** {@inheritDoc} */
   @Override
-  public boolean test(Key<?> key) {
+  public boolean test(@Nullable Key<?> key) {
     if (key == null) {
       throw new IllegalArgumentException("Key must not be null");
     }
@@ -73,13 +74,16 @@ public final class KeyAnnotationsPredicate implements Predicate<Key<?>> {
     } else if (ANY_MATCH == mode) {
       return key.annotations().stream().anyMatch(wrapperPredicate);
     } else {
-      return !key.annotations().isEmpty() && key.annotations().stream().allMatch(wrapperPredicate);
+      return !key.annotations().isEmpty()
+          && key.annotations().stream().allMatch(wrapperPredicate)
+          && annotationQueries.stream()
+              .allMatch(query -> key.annotations().stream().anyMatch(query));
     }
   }
 
   /** {@inheritDoc} */
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof KeyAnnotationsPredicate)) return false;
     KeyAnnotationsPredicate that = (KeyAnnotationsPredicate) o;
     return mode == that.mode && Objects.equals(annotationQueries, that.annotationQueries);
@@ -112,7 +116,7 @@ public final class KeyAnnotationsPredicate implements Predicate<Key<?>> {
         result.append(", ");
       }
 
-      result.append(annotationQuery.toString());
+      result.append(annotationQuery);
     }
 
     return result.append("]").toString();
@@ -189,16 +193,22 @@ public final class KeyAnnotationsPredicate implements Predicate<Key<?>> {
      * @return current builder
      */
     public AnnotationPredicates having(
-        Function<
+        @Nullable
+            Function<
                 AnnotationPredicate.AnnotationClass,
-                AnnotationPredicate.AnnotationMembersPredicate<?>>
+                AnnotationPredicate.@Nullable AnnotationMembersPredicate<?>>
             annotationQueryModifier) {
       if (annotationQueryModifier == null) {
         throw new IllegalArgumentException("annotationQueryModifier cannot be null");
       }
 
-      annotationQueries.add(
-          annotationQueryModifier.apply(AnnotationPredicate.annotationPredicate()).build());
+      final var annotationMembersPredicate =
+          annotationQueryModifier.apply(AnnotationPredicate.annotationPredicate());
+      if (annotationMembersPredicate == null) {
+        throw new IllegalArgumentException("annotationQueryModifier returned null");
+      }
+
+      annotationQueries.add(annotationMembersPredicate.build());
       return this;
     }
 
@@ -208,7 +218,7 @@ public final class KeyAnnotationsPredicate implements Predicate<Key<?>> {
      * @param annotationPredicate to add
      * @return current builder
      */
-    public AnnotationPredicates having(AnnotationPredicate<?> annotationPredicate) {
+    public AnnotationPredicates having(@Nullable AnnotationPredicate<?> annotationPredicate) {
       if (annotationPredicate == null) {
         throw new IllegalArgumentException("annotationPredicate cannot be null");
       }

--- a/src/main/java/io/github/suppierk/inject/query/package-info.java
+++ b/src/main/java/io/github/suppierk/inject/query/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.github.suppierk.inject.query;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/io/github/suppierk/utils/Memoized.java
+++ b/src/main/java/io/github/suppierk/utils/Memoized.java
@@ -24,12 +24,14 @@
 package io.github.suppierk.utils;
 
 import jakarta.inject.Provider;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Provides simple implementation of the lazily computed value which gets evaluated once.
@@ -47,7 +49,7 @@ import java.util.stream.Stream;
 public final class Memoized<T> implements Provider<T>, Supplier<T> {
   private final Provider<T> provider;
   private final Lock lock;
-  private final AtomicReference<T> value;
+  private final AtomicReference<@Nullable T> value;
 
   /**
    * Default constructor.
@@ -55,7 +57,7 @@ public final class Memoized<T> implements Provider<T>, Supplier<T> {
    * @param provider to invoke to compute the value
    * @throws IllegalArgumentException if {@link Provider} is {@code null}
    */
-  private Memoized(Provider<T> provider) {
+  private Memoized(@Nullable Provider<T> provider) {
     if (provider == null) {
       throw new IllegalArgumentException("Provider is null");
     }
@@ -72,7 +74,8 @@ public final class Memoized<T> implements Provider<T>, Supplier<T> {
    * @return new {@link Memoized} instance
    * @param <T> is the type of the value
    */
-  public static <T> Memoized<T> memoizedProvider(Provider<T> provider) {
+  @SuppressWarnings("squid:S6416")
+  public static <T> Memoized<T> memoizedProvider(@Nullable Provider<T> provider) {
     return new Memoized<>(provider);
   }
 
@@ -84,7 +87,7 @@ public final class Memoized<T> implements Provider<T>, Supplier<T> {
    * @param <T> is the type of the value
    * @throws IllegalArgumentException if {@link Supplier} is {@code null}
    */
-  public static <T> Memoized<T> memoizedSupplier(Supplier<T> supplier) {
+  public static <T> Memoized<T> memoizedSupplier(@Nullable Supplier<T> supplier) {
     if (supplier == null) {
       throw new IllegalArgumentException("Supplier is null");
     }
@@ -128,7 +131,7 @@ public final class Memoized<T> implements Provider<T>, Supplier<T> {
       }
     }
 
-    return localRef;
+    return Objects.requireNonNull(localRef);
   }
 
   /**
@@ -165,8 +168,10 @@ public final class Memoized<T> implements Provider<T>, Supplier<T> {
    * @throws NullPointerException if value is evaluated and the given action is {@code null}
    */
   public void ifPresent(Consumer<T> action) {
-    if (isPresent()) {
-      action.accept(value.get());
+    final var localRef = value.get();
+
+    if (localRef != null) {
+      action.accept(localRef);
     }
   }
 
@@ -180,8 +185,10 @@ public final class Memoized<T> implements Provider<T>, Supplier<T> {
    *     no value is evaluated and the given empty-based action is {@code null}.
    */
   public void ifPresentOrElse(Consumer<? super T> action, Runnable emptyAction) {
-    if (isPresent()) {
-      action.accept(value.get());
+    final var localRef = value.get();
+
+    if (localRef != null) {
+      action.accept(localRef);
     } else {
       emptyAction.run();
     }
@@ -201,11 +208,7 @@ public final class Memoized<T> implements Provider<T>, Supplier<T> {
    * @return the memoized value as a {@code Stream}
    */
   public Stream<T> stream() {
-    if (isEmpty()) {
-      return Stream.empty();
-    } else {
-      return Stream.of(value.get());
-    }
+    return Stream.ofNullable(value.get());
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/io/github/suppierk/utils/package-info.java
+++ b/src/main/java/io/github/suppierk/utils/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.github.suppierk.utils;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 open module io.github.suppierk.inject {
   requires jakarta.inject;
+  requires static transitive org.jspecify;
 
   exports io.github.suppierk.inject;
   exports io.github.suppierk.utils;

--- a/src/test/java/io/github/suppierk/inject/BuilderBuildReuseTest.java
+++ b/src/test/java/io/github/suppierk/inject/BuilderBuildReuseTest.java
@@ -1,0 +1,64 @@
+package io.github.suppierk.inject;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+class BuilderBuildReuseTest {
+  static class CapturesInjector {
+    final Injector injector;
+
+    @Inject
+    CapturesInjector(Injector injector) {
+      this.injector = injector;
+    }
+  }
+
+  @Singleton
+  static class SingletonService {}
+
+  @Test
+  void separateBuildsUseTheirOwnInjectorReference() {
+    final var builder = Injector.injector().add(CapturesInjector.class);
+
+    final var first = builder.build();
+    final var second = builder.build();
+
+    assertSame(first, first.get(CapturesInjector.class).injector);
+    assertSame(second, second.get(CapturesInjector.class).injector);
+  }
+
+  @Test
+  void separateBuildsDoNotShareSingletonInstances() {
+    final var builder = Injector.injector().add(SingletonService.class);
+
+    final var first = builder.build();
+    final var second = builder.build();
+
+    assertNotSame(first.get(SingletonService.class), second.get(SingletonService.class));
+  }
+
+  @Test
+  void separateCopyBuilderBuildsUseTheirOwnInjectorReference() {
+    final var builder = Injector.injector().add(CapturesInjector.class).build().copy();
+
+    final var first = builder.build();
+    final var second = builder.build();
+
+    assertSame(first, first.get(CapturesInjector.class).injector);
+    assertSame(second, second.get(CapturesInjector.class).injector);
+  }
+
+  @Test
+  void separateCopyBuilderBuildsDoNotShareSingletonInstances() {
+    final var builder = Injector.injector().add(SingletonService.class).build().copy();
+
+    final var first = builder.build();
+    final var second = builder.build();
+
+    assertNotSame(first.get(SingletonService.class), second.get(SingletonService.class));
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/BuilderFailureAtomicityTest.java
+++ b/src/test/java/io/github/suppierk/inject/BuilderFailureAtomicityTest.java
@@ -1,0 +1,201 @@
+package io.github.suppierk.inject;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unused")
+class BuilderFailureAtomicityTest {
+  static class InvalidParameterizedProviderFactory {
+    @Provides
+    List<String> dependency() {
+      return List.of("value");
+    }
+  }
+
+  static class DuplicateProviderFactory {
+    @Provides
+    Long first() {
+      return 1L;
+    }
+
+    @Provides
+    Long second() {
+      return 2L;
+    }
+  }
+
+  static class ValidDependency {}
+
+  static class CycleFirst {}
+
+  static class CycleSecond {}
+
+  static class ProviderCycleFactory {
+    @Provides
+    CycleFirst first(CycleSecond second) {
+      return new CycleFirst();
+    }
+
+    @Provides
+    CycleSecond second(CycleFirst first) {
+      return new CycleSecond();
+    }
+  }
+
+  @Test
+  void failedAddDoesNotKeepClassNodeFromParameterizedProviderFailure() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(InvalidParameterizedProviderFactory.class),
+        "Invalid @Provides method must fail registration");
+
+    final var injector = assertDoesNotThrow(builder::build, "Failed add must leave builder usable");
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(InvalidParameterizedProviderFactory.class),
+        "Failed add must not keep a partial class binding");
+  }
+
+  @Test
+  void failedAddDoesNotKeepClassNodeFromDuplicateProviderFailure() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(DuplicateProviderFactory.class),
+        "Duplicate @Provides methods must fail registration");
+
+    final var injector = assertDoesNotThrow(builder::build, "Failed add must leave builder usable");
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(DuplicateProviderFactory.class),
+        "Failed add must not keep a partial class binding");
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(Long.class),
+        "Failed add must not keep provider bindings registered before duplicate detection failed");
+  }
+
+  @Test
+  void failedAddDoesNotKeepBindingsFromProviderCycleFailure() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(ProviderCycleFactory.class),
+        "Provider cycles must fail registration");
+
+    final var injector = assertDoesNotThrow(builder::build, "Failed add must leave builder usable");
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(ProviderCycleFactory.class),
+        "Failed add must not keep a partial factory binding");
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(CycleFirst.class),
+        "Failed add must not keep provider bindings registered before cycle detection failed");
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(CycleSecond.class),
+        "Failed add must not keep the provider binding that failed cycle detection");
+  }
+
+  @Test
+  void failedClassAddPreservesPreviousSuccessfulBindings() {
+    final var builder = Injector.injector().add(ValidDependency.class);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(InvalidParameterizedProviderFactory.class),
+        "Invalid @Provides method must fail registration");
+
+    final var injector = assertDoesNotThrow(builder::build, "Failed add must leave builder usable");
+
+    assertDoesNotThrow(
+        () -> injector.get(ValidDependency.class),
+        "Failed add must preserve bindings registered before the failed call");
+  }
+
+  @Test
+  void failedValueAddPreservesPreviousSuccessfulBindings() {
+    final Integer registeredValue = 1_234_567;
+    final var builder = Injector.injector().add(registeredValue);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add("kept", (Object) null),
+        "Invalid value in varargs batch must fail registration");
+
+    final var injector = assertDoesNotThrow(builder::build, "Failed add must leave builder usable");
+
+    assertSame(
+        registeredValue,
+        injector.get(Integer.class),
+        "Failed add must preserve values registered before the failed call");
+  }
+
+  @Test
+  void failedVarargsAddDoesNotKeepAnyClassFromBatch() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(ValidDependency.class, InvalidParameterizedProviderFactory.class),
+        "Invalid class in varargs batch must fail registration");
+
+    final var injector = assertDoesNotThrow(builder::build, "Failed add must leave builder usable");
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(ValidDependency.class),
+        "Failed varargs add must not keep earlier class bindings from the same batch");
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(InvalidParameterizedProviderFactory.class),
+        "Failed varargs add must not keep failed class bindings from the same batch");
+  }
+
+  @Test
+  void failedVarargsValueAddDoesNotKeepAnyValueFromBatch() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add("kept", (Object) null),
+        "Invalid value in varargs batch must fail registration");
+
+    final var injector = assertDoesNotThrow(builder::build, "Failed add must leave builder usable");
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(String.class),
+        "Failed varargs value add must not keep earlier value bindings from the same batch");
+  }
+
+  @Test
+  void duplicateInVarargsValueAddDoesNotKeepAnyValueFromBatch() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add("first", "second"),
+        "Duplicate value in varargs batch must fail registration");
+
+    final var injector = assertDoesNotThrow(builder::build, "Failed add must leave builder usable");
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(String.class),
+        "Failed duplicate value add must not keep earlier value bindings from the same batch");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/CaptiveDependencyValidationTest.java
+++ b/src/test/java/io/github/suppierk/inject/CaptiveDependencyValidationTest.java
@@ -1,0 +1,286 @@
+/*
+ * MIT License
+ *
+ * Copyright 2026 Roman Khlebnov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.suppierk.inject;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class CaptiveDependencyValidationTest {
+  static class NonSingletonDependency {}
+
+  @Singleton
+  static class SingletonDependency {}
+
+  static class ObjectDependency {}
+
+  @Singleton
+  static class ServiceDependency {}
+
+  static class NonSingletonServiceDependency extends ServiceDependency {}
+
+  @Singleton
+  static class SingletonWithConstructorCaptiveDependency {
+    @Inject
+    SingletonWithConstructorCaptiveDependency(NonSingletonDependency dependency) {}
+  }
+
+  @Singleton
+  static class SingletonWithFieldCaptiveDependency {
+    @Inject NonSingletonDependency dependency;
+  }
+
+  @Singleton
+  static class SingletonWithSingletonDependency {
+    @Inject
+    SingletonWithSingletonDependency(SingletonDependency dependency) {}
+  }
+
+  @Singleton
+  static class SingletonWithObjectDependency {
+    @Inject
+    SingletonWithObjectDependency(ObjectDependency dependency) {}
+  }
+
+  @Singleton
+  static class SingletonWithProviderDependency {
+    @Inject
+    SingletonWithProviderDependency(Provider<NonSingletonDependency> dependency) {}
+  }
+
+  @Singleton
+  static class SingletonWithSupplierDependency {
+    @Inject
+    SingletonWithSupplierDependency(Supplier<NonSingletonDependency> dependency) {}
+  }
+
+  static class NonSingletonWithNonSingletonDependency {
+    @Inject
+    NonSingletonWithNonSingletonDependency(NonSingletonDependency dependency) {}
+  }
+
+  static class NonSingletonWithSingletonDependency {
+    @Inject
+    NonSingletonWithSingletonDependency(SingletonDependency dependency) {}
+  }
+
+  static class SingletonProviderMethodFactory {
+    @Provides
+    @Singleton
+    SingletonProduct singletonProduct(NonSingletonDependency dependency) {
+      return new SingletonProduct();
+    }
+  }
+
+  static class SingletonReturnTypeProviderMethodFactory {
+    @Provides
+    SingletonReturnType singletonReturnType(NonSingletonDependency dependency) {
+      return new SingletonReturnType();
+    }
+  }
+
+  static class SingletonProduct {}
+
+  @Singleton
+  static class SingletonReturnType {}
+
+  static class NonSingletonProduct {}
+
+  @Singleton
+  static class SingletonWithReplaceableDependency {
+    @Inject
+    SingletonWithReplaceableDependency(ServiceDependency dependency) {}
+  }
+
+  @Test
+  void singletonMustNotDependDirectlyOnNonSingletonConstructorDependency() {
+    final var builder =
+        Injector.injector()
+            .add(SingletonWithConstructorCaptiveDependency.class, NonSingletonDependency.class);
+
+    final var exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            builder::build,
+            "Singleton constructor dependency on non-singleton must be rejected");
+
+    assertCaptiveDependencyMessage(exception);
+  }
+
+  @Test
+  void singletonMustNotDependDirectlyOnNonSingletonFieldDependency() {
+    final var builder =
+        Injector.injector()
+            .add(SingletonWithFieldCaptiveDependency.class, NonSingletonDependency.class);
+
+    final var exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            builder::build,
+            "Singleton field dependency on non-singleton must be rejected");
+
+    assertCaptiveDependencyMessage(exception);
+  }
+
+  @Test
+  void singletonMayDependDirectlyOnSingletonDependency() {
+    assertDoesNotThrow(
+        () ->
+            Injector.injector()
+                .add(SingletonWithSingletonDependency.class, SingletonDependency.class)
+                .build(),
+        "Singleton dependency on singleton must be allowed");
+  }
+
+  @Test
+  void singletonMayDependDirectlyOnObjectDependency() {
+    assertDoesNotThrow(
+        () ->
+            Injector.injector()
+                .add(SingletonWithObjectDependency.class)
+                .add(new ObjectDependency())
+                .build(),
+        "Singleton dependency on registered object must be allowed");
+  }
+
+  @Test
+  void singletonMayDependOnNonSingletonProvider() {
+    assertDoesNotThrow(
+        () ->
+            Injector.injector()
+                .add(SingletonWithProviderDependency.class, NonSingletonDependency.class)
+                .build(),
+        "Singleton Provider dependency on non-singleton must be allowed");
+  }
+
+  @Test
+  void singletonMayDependOnNonSingletonSupplier() {
+    assertDoesNotThrow(
+        () ->
+            Injector.injector()
+                .add(SingletonWithSupplierDependency.class, NonSingletonDependency.class)
+                .build(),
+        "Singleton Supplier dependency on non-singleton must be allowed");
+  }
+
+  @Test
+  void nonSingletonMayDependDirectlyOnNonSingletonDependency() {
+    assertDoesNotThrow(
+        () ->
+            Injector.injector()
+                .add(NonSingletonWithNonSingletonDependency.class, NonSingletonDependency.class)
+                .build(),
+        "Non-singleton dependency on non-singleton must be allowed");
+  }
+
+  @Test
+  void nonSingletonMayDependDirectlyOnSingletonDependency() {
+    assertDoesNotThrow(
+        () ->
+            Injector.injector()
+                .add(NonSingletonWithSingletonDependency.class, SingletonDependency.class)
+                .build(),
+        "Non-singleton dependency on singleton must be allowed");
+  }
+
+  @Test
+  void singletonProviderMethodMustNotDependDirectlyOnNonSingletonDependency() {
+    final var builder =
+        Injector.injector().add(SingletonProviderMethodFactory.class, NonSingletonDependency.class);
+
+    final var exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            builder::build,
+            "Singleton provider method dependency on non-singleton must be rejected");
+
+    assertCaptiveDependencyMessage(exception);
+  }
+
+  @Test
+  void singletonReturnTypeProviderMethodMustNotDependDirectlyOnNonSingletonDependency() {
+    final var builder =
+        Injector.injector()
+            .add(SingletonReturnTypeProviderMethodFactory.class, NonSingletonDependency.class);
+
+    final var exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            builder::build,
+            "Provider method returning @Singleton type and depending on non-singleton must be rejected");
+
+    assertCaptiveDependencyMessage(exception);
+  }
+
+  @Test
+  void nonSingletonProviderMethodMayDependDirectlyOnNonSingletonDependency() {
+    assertDoesNotThrow(
+        () ->
+            Injector.injector()
+                .add(NonSingletonFactory.class, NonSingletonDependency.class)
+                .build(),
+        "Non-singleton provider method dependency on non-singleton must be allowed");
+  }
+
+  @Test
+  void replacementMustUseReplacementScopeForCaptiveDependencyValidation() {
+    final var original =
+        Injector.injector()
+            .add(SingletonWithReplaceableDependency.class, ServiceDependency.class)
+            .build();
+
+    final var copyBuilder =
+        original.copy().replace(ServiceDependency.class, NonSingletonServiceDependency.class);
+
+    final var exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            copyBuilder::build,
+            "Replacement scope must be used for captive dependency validation");
+
+    assertCaptiveDependencyMessage(exception);
+  }
+
+  static class NonSingletonFactory {
+    @Provides
+    NonSingletonProduct nonSingletonProduct(NonSingletonDependency dependency) {
+      return new NonSingletonProduct();
+    }
+  }
+
+  private static void assertCaptiveDependencyMessage(IllegalArgumentException exception) {
+    final var message = exception.getMessage();
+
+    assertTrue(message.contains("Captive dependency"), "Message must identify captive dependency");
+    assertTrue(message.contains("@Singleton"), "Message must mention singleton scope");
+    assertTrue(message.contains("Provider"), "Message must suggest Provider as an alternative");
+    assertTrue(message.contains("Supplier"), "Message must suggest Supplier as an alternative");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/CopyBuilderValidationTest.java
+++ b/src/test/java/io/github/suppierk/inject/CopyBuilderValidationTest.java
@@ -1,0 +1,76 @@
+package io.github.suppierk.inject;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unused")
+class CopyBuilderValidationTest {
+  static class Original {}
+
+  static class CyclicReplacement extends Original {
+    @Inject
+    CyclicReplacement(Original original) {}
+  }
+
+  abstract static class AbstractReplacement extends Original {
+    AbstractReplacement() {}
+  }
+
+  static class ParentToken {}
+
+  static class ChildToken extends ParentToken {}
+
+  static class UnrelatedToken {}
+
+  @Test
+  void replacementCycleFailsDuringBuild() {
+    final var builder =
+        Injector.injector()
+            .add(Original.class)
+            .build()
+            .copy()
+            .replace(Original.class, CyclicReplacement.class);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        builder::build,
+        "Replacement cycle must fail during build instead of causing recursive resolution");
+  }
+
+  @Test
+  void abstractReplacementClassFailsDuringReplacement() {
+    final var builder = Injector.injector().add(Original.class).build().copy();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.replace(Original.class, AbstractReplacement.class),
+        "Abstract replacement classes must be rejected consistently with regular registration");
+  }
+
+  @Test
+  void replacingObjectWithUnassignableInstanceFails() {
+    final var registered = new ParentToken();
+    final var replacement = new UnrelatedToken();
+    final var builder = Injector.injector().add(registered).build().copy();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.replace(registered, replacement),
+        "Object replacement must verify that the replacement type is assignable to the original type");
+  }
+
+  @Test
+  void replacingDifferentObjectInstanceOfSameOriginalClassFails() {
+    final var registered = new ParentToken();
+    final var notRegistered = new ParentToken();
+    final var replacement = new ChildToken();
+    final var builder = Injector.injector().add(registered).build().copy();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.replace(notRegistered, replacement),
+        "Object replacement must verify that the original instance is registered");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/InjectorCloseIdempotencyTest.java
+++ b/src/test/java/io/github/suppierk/inject/InjectorCloseIdempotencyTest.java
@@ -1,0 +1,41 @@
+package io.github.suppierk.inject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Singleton;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class InjectorCloseIdempotencyTest {
+  @Singleton
+  static class Resource implements AutoCloseable {
+    private final AtomicInteger closeCount = new AtomicInteger();
+
+    @Override
+    public void close() {
+      closeCount.incrementAndGet();
+    }
+  }
+
+  @Test
+  void closingInjectorTwiceClosesValueOnlyOnce() {
+    final var resource = new Resource();
+    final var injector = Injector.injector().add(resource).build();
+
+    injector.close();
+    injector.close();
+
+    assertEquals(1, resource.closeCount.get(), "Value resources must be closed at most once");
+  }
+
+  @Test
+  void closingInjectorTwiceClosesSingletonOnlyOnce() {
+    final var injector = Injector.injector().add(Resource.class).build();
+    final var resource = injector.get(Resource.class);
+
+    injector.close();
+    injector.close();
+
+    assertEquals(1, resource.closeCount.get(), "Singleton must be closed at most once");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/InjectorCopyBuilderTest.java
+++ b/src/test/java/io/github/suppierk/inject/InjectorCopyBuilderTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 class InjectorCopyBuilderTest {
 
+  @Singleton
   static class Dependency {}
 
   @Singleton

--- a/src/test/java/io/github/suppierk/inject/InjectorSelfReferenceQualifierTest.java
+++ b/src/test/java/io/github/suppierk/inject/InjectorSelfReferenceQualifierTest.java
@@ -1,0 +1,46 @@
+package io.github.suppierk.inject;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unused")
+class InjectorSelfReferenceQualifierTest {
+  @Named("qualified")
+  static class QualifierSource {}
+
+  static class QualifiedInjectorConsumer {
+    private final Injector injector;
+
+    @Inject
+    QualifiedInjectorConsumer(@Named("qualified") Injector injector) {
+      this.injector = injector;
+    }
+  }
+
+  @Test
+  void qualifiedInjectorKeyDoesNotReturnUnqualifiedSelfReference() {
+    final var qualifier = QualifierSource.class.getAnnotation(Named.class);
+    final var injector = Injector.injector().build();
+    final var qualifiedInjectorKey = new Key<>(Injector.class, Set.of(qualifier));
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(qualifiedInjectorKey),
+        "Qualified Injector keys must not resolve to the unqualified self reference");
+  }
+
+  @Test
+  void qualifiedInjectorInjectionFailsAsMissingBinding() {
+    final var builder = Injector.injector().add(QualifiedInjectorConsumer.class);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        builder::build,
+        "Qualified Injector injection points must not be satisfied by the unqualified self reference");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/InjectorTest.java
+++ b/src/test/java/io/github/suppierk/inject/InjectorTest.java
@@ -79,7 +79,7 @@ class InjectorTest {
         .forClass(Injector.class)
         .withPrefabValues(
             Node.class, new Value<>(injectorReference, "A"), new Value<>(injectorReference, "B"))
-        .withIgnoredFields("currentInjector")
+        .withIgnoredFields("currentInjector", "closed")
         .verify();
   }
 
@@ -170,8 +170,15 @@ class InjectorTest {
   }
 
   @Test
-  void findOneReturnsNonEmptyOptionalForSingleOption() {
+  void findOneReturnsNonEmptyOptionalForSingleOption() throws NoSuchMethodException {
     final var injector = Injector.injector().add(TestValueProvider.class).build();
+    final var expectedKey =
+        new Key<>(
+            TestValue.class,
+            Set.of(
+                TestValueProvider.class
+                    .getDeclaredMethod("firstValue")
+                    .getAnnotation(Named.class)));
 
     final var result =
         assertDoesNotThrow(
@@ -189,6 +196,7 @@ class InjectorTest {
             "Must not throw IllegalStateException when there is one option");
     assertNotNull(result, "Result must not be null");
     assertTrue(result.isPresent(), "Result must be present");
+    assertEquals(expectedKey, result.orElseThrow(), "Result key must match the only matching key");
   }
 
   @Test
@@ -467,6 +475,20 @@ class InjectorTest {
           IllegalArgumentException.class,
           () -> builder.replace(OldValue.class, NewValue.class),
           "Replacing missing dependency must throw an exception");
+    }
+
+    @Test
+    void successfulObjectReplacementReturnsSameBuilder() {
+      final var original = new OldValue();
+      final var replacement = new NewValue();
+      final var builder = Injector.injector().add(original).build().copy();
+
+      assertSame(
+          builder,
+          assertDoesNotThrow(
+              () -> builder.replace(original, replacement),
+              "Replacement must not throw an exception"),
+          "Successful object replacement must return the same builder instance");
     }
 
     @Test

--- a/src/test/java/io/github/suppierk/inject/InjectorYamlRenderingTest.java
+++ b/src/test/java/io/github/suppierk/inject/InjectorYamlRenderingTest.java
@@ -23,6 +23,8 @@
 
 package io.github.suppierk.inject;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
@@ -31,7 +33,39 @@ import org.junit.jupiter.api.Test;
 
 class InjectorYamlRenderingTest {
 
+  @Singleton
   static class Dependency {}
+
+  static class StableAlpha {}
+
+  static class StableBeta {}
+
+  static class StableConsumer {
+    @Inject
+    StableConsumer(StableBeta beta) {}
+  }
+
+  static class FieldA {}
+
+  static class FieldB {}
+
+  static class FieldConsumer {
+    @Inject FieldB fieldB;
+
+    @Inject FieldA fieldA;
+  }
+
+  static class ChainLeaf {}
+
+  static class ChainMiddle {
+    @Inject
+    ChainMiddle(ChainLeaf leaf) {}
+  }
+
+  static class ChainRoot {
+    @Inject
+    ChainRoot(ChainMiddle middle) {}
+  }
 
   @Singleton
   static class Service implements AutoCloseable {
@@ -52,12 +86,55 @@ class InjectorYamlRenderingTest {
   }
 
   @Test
+  void sameGraphMustRenderSameYamlRegardlessOfRegistrationOrder() {
+    final Injector first =
+        Injector.injector().add(StableConsumer.class, StableAlpha.class, StableBeta.class).build();
+    final Injector second =
+        Injector.injector().add(StableBeta.class, StableConsumer.class, StableAlpha.class).build();
+
+    assertEquals(first.toString(), second.toString(), "Equivalent graphs must render identically");
+  }
+
+  @Test
+  void injectedFieldsMustRenderInStableOrder() {
+    final Injector injector =
+        Injector.injector().add(FieldConsumer.class, FieldB.class, FieldA.class).build();
+
+    final String yaml = injector.toString();
+    final int consumerIndex = yaml.indexOf(FieldConsumer.class.getName());
+    final int fieldsIndex = yaml.indexOf("fields:", consumerIndex);
+    final int fieldAIndex = yaml.indexOf(FieldA.class.getName(), fieldsIndex);
+    final int fieldBIndex = yaml.indexOf(FieldB.class.getName(), fieldsIndex);
+
+    assertTrue(fieldAIndex > fieldsIndex, () -> "Expected FieldA in consumer fields:\n" + yaml);
+    assertTrue(fieldBIndex > fieldsIndex, () -> "Expected FieldB in consumer fields:\n" + yaml);
+    assertTrue(fieldAIndex < fieldBIndex, () -> "Expected field YAML to be sorted:\n" + yaml);
+  }
+
+  @Test
+  void dependenciesMustRenderBeforeDependents() {
+    final Injector injector =
+        Injector.injector().add(ChainRoot.class, ChainMiddle.class, ChainLeaf.class).build();
+
+    final String yaml = injector.toString();
+    final int leafIndex = yaml.indexOf(ChainLeaf.class.getName());
+    final int middleIndex = yaml.indexOf(ChainMiddle.class.getName());
+    final int rootIndex = yaml.indexOf(ChainRoot.class.getName());
+
+    assertTrue(leafIndex >= 0, () -> "Expected ChainLeaf in YAML:\n" + yaml);
+    assertTrue(middleIndex >= 0, () -> "Expected ChainMiddle in YAML:\n" + yaml);
+    assertTrue(rootIndex >= 0, () -> "Expected ChainRoot in YAML:\n" + yaml);
+    assertTrue(leafIndex < middleIndex, () -> "Expected leaf before middle:\n" + yaml);
+    assertTrue(middleIndex < rootIndex, () -> "Expected middle before root:\n" + yaml);
+  }
+
+  @Test
   void injectorDependenciesAppearInYamlAndClose() {
     final Injector injector = Injector.injector().add(Dependency.class, Service.class).build();
 
     // Exercise resolution and ensure the injector self-reference works.
     final Service service = injector.get(Service.class);
-    assertTrue(service.injector == injector, "Service must receive the current injector instance");
+    assertSame(service.injector, injector, "Service must receive the current injector instance");
 
     final String yaml = injector.toString();
 

--- a/src/test/java/io/github/suppierk/inject/KeyTest.java
+++ b/src/test/java/io/github/suppierk/inject/KeyTest.java
@@ -12,6 +12,7 @@ import jakarta.inject.Qualifier;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -22,7 +23,9 @@ import org.junit.jupiter.api.Test;
 class KeyTest {
   @Test
   void objectMethodsMustWorkAsExpected() {
-    EqualsVerifier.forClass(Key.class).verify();
+    EqualsVerifier.forClass(Key.class)
+        .withCachedHashCode("hashCode", "calculateHashCode", new Key<>(String.class, null))
+        .verify();
   }
 
   @Test
@@ -62,6 +65,24 @@ class KeyTest {
     final var actualYaml = key.toYamlString(false, 0);
 
     assertEquals(expectedYaml, actualYaml, "YAML string must match the expectation");
+  }
+
+  @Test
+  void toYamlStringMultipleAnnotationsMustHaveStableOrder() {
+    final var expectedYaml =
+        Stream.of(
+                "type: " + ConsoleConstants.cyanBold(String.class.getName()),
+                "annotations:",
+                "  - '@" + ConsoleConstants.yellow(AlphaQualifier.class.getName()) + "()'",
+                "  - '@" + ConsoleConstants.yellow(BetaQualifier.class.getName()) + "()'")
+            .collect(Collectors.joining(String.format("%n")));
+
+    final var clazz = MultipleStableQualifierAnnotations.class;
+    final var alphaQualifier = clazz.getAnnotation(AlphaQualifier.class);
+    final var betaQualifier = clazz.getAnnotation(BetaQualifier.class);
+    final var key = new Key<>(String.class, Set.of(betaQualifier, alphaQualifier));
+
+    assertEquals(expectedYaml, key.toYamlString(false, 0), "YAML string must match expectation");
   }
 
   @Test
@@ -127,6 +148,17 @@ class KeyTest {
     }
 
     @Test
+    void constructorFailsForNullAnnotationElement() {
+      final var annotations = new HashSet<Annotation>();
+      annotations.add(null);
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new Key<>(String.class, annotations),
+          "Null annotation element must throw an exception");
+    }
+
+    @Test
     void constructorForClassMustWorkAsExpected() {
       final var clazz = String.class;
 
@@ -178,6 +210,18 @@ class KeyTest {
       assertNotNull(key.toString(), "toString must not be null");
     }
   }
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface AlphaQualifier {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface BetaQualifier {}
+
+  @AlphaQualifier
+  @BetaQualifier
+  static class MultipleStableQualifierAnnotations {}
 
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/io/github/suppierk/inject/PostConstructAdjusterTest.java
+++ b/src/test/java/io/github/suppierk/inject/PostConstructAdjusterTest.java
@@ -1,0 +1,206 @@
+/*
+ * MIT License
+ *
+ * Copyright 2026 Roman Khlebnov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the “Software”), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.suppierk.inject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import org.junit.jupiter.api.Test;
+
+class PostConstructAdjusterTest {
+  static class Dependency {
+    final String value = "dependency";
+  }
+
+  static class MissingDependency {}
+
+  static class Adjustable {
+    @Inject Dependency dependency;
+
+    Injector injector;
+    String value;
+  }
+
+  static class CountsAdjustments {
+    int adjustmentCount;
+  }
+
+  @Singleton
+  static class SingletonCountsAdjustments {
+    int adjustmentCount;
+  }
+
+  static class ThrowsFromAdjuster {}
+
+  static class RequiresHiddenDependency {
+    MissingDependency missingDependency;
+  }
+
+  static class Base {}
+
+  static class Replacement extends Base {
+    boolean adjusted;
+  }
+
+  @Test
+  void adjusterRunsAfterInjectionAndCanUseInjector() {
+    final Injector injector =
+        Injector.injector()
+            .add(Dependency.class)
+            .add(
+                Adjustable.class,
+                (currentInjector, adjustable) -> {
+                  adjustable.injector = currentInjector;
+                  adjustable.value = adjustable.dependency.value;
+                })
+            .build();
+
+    final var adjustable = injector.get(Adjustable.class);
+
+    assertNotNull(adjustable.dependency, "Field injection must happen before adjustment");
+    assertSame(injector, adjustable.injector, "Adjuster must receive current injector");
+    assertEquals("dependency", adjustable.value, "Adjuster must be able to tweak instance state");
+  }
+
+  @Test
+  void nonSingletonAdjusterRunsForEveryCreatedInstance() {
+    final var adjustments = new AtomicInteger();
+    final Injector injector =
+        Injector.injector()
+            .add(
+                CountsAdjustments.class,
+                (currentInjector, instance) ->
+                    instance.adjustmentCount = adjustments.incrementAndGet())
+            .build();
+
+    final var first = injector.get(CountsAdjustments.class);
+    final var second = injector.get(CountsAdjustments.class);
+
+    assertEquals(1, first.adjustmentCount, "First instance must be adjusted once");
+    assertEquals(2, second.adjustmentCount, "Second instance must be adjusted once too");
+  }
+
+  @Test
+  void singletonAdjusterRunsOnce() {
+    final var adjustments = new AtomicInteger();
+    final Injector injector =
+        Injector.injector()
+            .add(
+                SingletonCountsAdjustments.class,
+                (currentInjector, instance) ->
+                    instance.adjustmentCount = adjustments.incrementAndGet())
+            .build();
+
+    final var first = injector.get(SingletonCountsAdjustments.class);
+    final var second = injector.get(SingletonCountsAdjustments.class);
+
+    assertSame(first, second, "Singleton instance must be reused");
+    assertEquals(1, first.adjustmentCount, "Singleton must be adjusted once");
+    assertEquals(1, adjustments.get(), "Adjuster must be invoked once");
+  }
+
+  @Test
+  void adjusterExceptionsPropagateUnchanged() {
+    final var expected = new UnsupportedOperationException("boom");
+    final Injector injector =
+        Injector.injector()
+            .add(
+                ThrowsFromAdjuster.class,
+                (currentInjector, instance) -> {
+                  throw expected;
+                })
+            .build();
+
+    final var thrown =
+        assertThrows(
+            UnsupportedOperationException.class, () -> injector.get(ThrowsFromAdjuster.class));
+
+    assertSame(expected, thrown, "Adjuster exception must propagate unchanged");
+  }
+
+  @Test
+  void hiddenAdjusterDependenciesFailAtRuntime() {
+    final Injector injector =
+        Injector.injector()
+            .add(
+                RequiresHiddenDependency.class,
+                (currentInjector, instance) ->
+                    instance.missingDependency = currentInjector.get(MissingDependency.class))
+            .build();
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> injector.get(RequiresHiddenDependency.class),
+        "Dependencies only used inside adjusters are runtime lookups");
+  }
+
+  @Test
+  void addFailsForNullAdjuster() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(Adjustable.class, (BiConsumer<Injector, Adjustable>) null),
+        "Null adjuster must throw an exception");
+  }
+
+  @Test
+  void replacementAdjusterRunsForReplacementClass() {
+    final Injector original = Injector.injector().add(Base.class).build();
+    final Injector replaced =
+        original
+            .copy()
+            .replace(
+                Base.class,
+                Replacement.class,
+                (injector, replacement) -> replacement.adjusted = true)
+            .build();
+
+    final var base = replaced.get(Base.class);
+    final var replacement =
+        assertInstanceOf(Replacement.class, base, "Base must refer to replacement");
+
+    assertTrue(replacement.adjusted, "Replacement adjuster must run");
+  }
+
+  @Test
+  void replaceFailsForNullAdjuster() {
+    final Injector injector = Injector.injector().add(Base.class).build();
+    final var copyBuilder = injector.copy();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> copyBuilder.replace(Base.class, Replacement.class, null),
+        "Null replacement adjuster must throw an exception");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/graph/ConstructsSingletonTest.java
+++ b/src/test/java/io/github/suppierk/inject/graph/ConstructsSingletonTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.suppierk.inject.FieldInformation;
 import io.github.suppierk.inject.Injector;
@@ -54,6 +55,31 @@ class ConstructsSingletonTest {
         .withPrefabValues(Parameter.class, redParameter, blueParameter)
         .withIgnoredFields("injectorReference", "constructor", "memoized", "onCloseConsumer")
         .verify();
+  }
+
+  @Test
+  void nullConstructorArgumentThrowsException() {
+    final var injectorReference = new InjectorReference();
+    final var constructor = Value.constructor();
+    final var parameters = List.<ParameterInformation>of();
+    final var fields = List.<FieldInformation>of();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new ConstructsSingleton<>(null, constructor, parameters, fields),
+        "Null injector reference must throw an exception");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new ConstructsSingleton<>(injectorReference, null, parameters, fields),
+        "Null constructor must throw an exception");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new ConstructsSingleton<>(injectorReference, constructor, null, fields),
+        "Null parameters information must throw an exception");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new ConstructsSingleton<>(injectorReference, constructor, parameters, null),
+        "Null fields information must throw an exception");
   }
 
   @Test

--- a/src/test/java/io/github/suppierk/inject/graph/ProvidesSingletonTest.java
+++ b/src/test/java/io/github/suppierk/inject/graph/ProvidesSingletonTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.suppierk.inject.FieldInformation;
 import io.github.suppierk.inject.Injector;
@@ -68,6 +69,51 @@ class ProvidesSingletonTest {
         .withPrefabValues(Parameter.class, redParameter, blueParameter)
         .withIgnoredFields("injectorReference", "memoized", "onCloseConsumer")
         .verify();
+  }
+
+  @Test
+  void nullConstructorArgumentThrowsException() {
+    final var injectorReference = new InjectorReference();
+    final var qualifier = new Key<>(String.class, Set.of());
+    final var method = Value.method();
+    final var methodReturnClass = String.class;
+    final var parameters = List.<ParameterInformation>of();
+    final var fields = List.<FieldInformation>of();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new ProvidesSingleton<>(null, qualifier, method, methodReturnClass, parameters, fields),
+        "Null injector reference must throw an exception");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new ProvidesSingleton<>(
+                injectorReference, null, method, methodReturnClass, parameters, fields),
+        "Null class key must throw an exception");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new ProvidesSingleton<>(
+                injectorReference, qualifier, null, methodReturnClass, parameters, fields),
+        "Null method must throw an exception");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new ProvidesSingleton<>(injectorReference, qualifier, method, null, parameters, fields),
+        "Null method return class must throw an exception");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new ProvidesSingleton<>(
+                injectorReference, qualifier, method, methodReturnClass, null, fields),
+        "Null parameters information must throw an exception");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new ProvidesSingleton<>(
+                injectorReference, qualifier, method, methodReturnClass, parameters, null),
+        "Null fields information must throw an exception");
   }
 
   @Test

--- a/src/test/java/io/github/suppierk/inject/limitations/InjectedFieldValidationTest.java
+++ b/src/test/java/io/github/suppierk/inject/limitations/InjectedFieldValidationTest.java
@@ -1,0 +1,38 @@
+package io.github.suppierk.inject.limitations;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.suppierk.inject.Injector;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unused")
+class InjectedFieldValidationTest {
+  static class StaticFieldConsumer {
+    @Inject private static String value;
+  }
+
+  static class FinalFieldConsumer {
+    @Inject private final String value = null;
+  }
+
+  @Test
+  void staticInjectedFieldFailsDuringRegistration() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(StaticFieldConsumer.class),
+        "Static field injection must fail during registration");
+  }
+
+  @Test
+  void finalInjectedFieldFailsDuringRegistration() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(FinalFieldConsumer.class),
+        "Final field injection must fail during registration");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/limitations/RawWrapperInjectionTest.java
+++ b/src/test/java/io/github/suppierk/inject/limitations/RawWrapperInjectionTest.java
@@ -1,0 +1,113 @@
+package io.github.suppierk.inject.limitations;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.suppierk.inject.Injector;
+import io.github.suppierk.inject.Provides;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings({"rawtypes", "unused"})
+class RawWrapperInjectionTest {
+  static class RawProviderConsumer {
+    private final Provider provider;
+
+    @Inject
+    RawProviderConsumer(Provider provider) {
+      this.provider = provider;
+    }
+  }
+
+  static class RawSupplierConsumer {
+    private final Supplier supplier;
+
+    @Inject
+    RawSupplierConsumer(Supplier supplier) {
+      this.supplier = supplier;
+    }
+  }
+
+  static class RawProviderFieldConsumer {
+    @Inject private Provider provider;
+  }
+
+  static class RawSupplierFieldConsumer {
+    @Inject private Supplier supplier;
+  }
+
+  static class RawProviderFactory {
+    @Provides
+    Provider dependency() {
+      return () -> "value";
+    }
+  }
+
+  static class RawSupplierFactory {
+    @Provides
+    Supplier dependency() {
+      return () -> "value";
+    }
+  }
+
+  @Test
+  void rawProviderInjectionFailsDuringRegistration() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(RawProviderConsumer.class),
+        "Raw Provider injection must fail during registration");
+  }
+
+  @Test
+  void rawSupplierInjectionFailsDuringRegistration() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(RawSupplierConsumer.class),
+        "Raw Supplier injection must fail during registration");
+  }
+
+  @Test
+  void rawProviderFieldInjectionFailsDuringRegistration() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(RawProviderFieldConsumer.class),
+        "Raw Provider field injection must fail during registration");
+  }
+
+  @Test
+  void rawSupplierFieldInjectionFailsDuringRegistration() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(RawSupplierFieldConsumer.class),
+        "Raw Supplier field injection must fail during registration");
+  }
+
+  @Test
+  void rawProviderReturnFailsDuringRegistration() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(RawProviderFactory.class),
+        "Raw Provider @Provides return types must fail during registration");
+  }
+
+  @Test
+  void rawSupplierReturnFailsDuringRegistration() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(RawSupplierFactory.class),
+        "Raw Supplier @Provides return types must fail during registration");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/limitations/UnsupportedGenericInjectionTest.java
+++ b/src/test/java/io/github/suppierk/inject/limitations/UnsupportedGenericInjectionTest.java
@@ -1,0 +1,157 @@
+package io.github.suppierk.inject.limitations;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.suppierk.inject.Injector;
+import io.github.suppierk.inject.Provides;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unused")
+class UnsupportedGenericInjectionTest {
+  static class WildcardWrapperConsumer {
+    private final Provider<? extends Number> number;
+
+    @Inject
+    WildcardWrapperConsumer(Provider<? extends Number> number) {
+      this.number = number;
+    }
+  }
+
+  static class TypeVariableWrapperConsumer<T> {
+    private final Provider<T> value;
+
+    @Inject
+    TypeVariableWrapperConsumer(Provider<T> value) {
+      this.value = value;
+    }
+  }
+
+  static class DirectTypeVariableConsumer<T> {
+    private final T value;
+
+    @Inject
+    DirectTypeVariableConsumer(T value) {
+      this.value = value;
+    }
+  }
+
+  static class GenericArrayConsumer<T> {
+    private final T[] values;
+
+    @Inject
+    GenericArrayConsumer(T[] values) {
+      this.values = values;
+    }
+  }
+
+  static class GenericArrayWrapperConsumer<T> {
+    private final Provider<T[]> values;
+
+    @Inject
+    GenericArrayWrapperConsumer(Provider<T[]> values) {
+      this.values = values;
+    }
+  }
+
+  static class BaseWithGenericField<T> {
+    @Inject private T value;
+  }
+
+  static class StringChildWithGenericField extends BaseWithGenericField<String> {}
+
+  static class TypeVariableProviderFactory<T> {
+    @Provides
+    T value() {
+      return null;
+    }
+  }
+
+  static class GenericArrayProviderFactory<T> {
+    @Provides
+    T[] values() {
+      return null;
+    }
+  }
+
+  @Test
+  void wildcardWrapperTypeFailsWithControlledException() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(WildcardWrapperConsumer.class),
+        "Wildcard wrapper types must fail with a controlled exception");
+  }
+
+  @Test
+  void typeVariableWrapperTypeFailsWithControlledException() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(TypeVariableWrapperConsumer.class),
+        "Type variable wrapper types must fail with a controlled exception");
+  }
+
+  @Test
+  void directTypeVariableInjectionFailsWithControlledException() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(DirectTypeVariableConsumer.class),
+        "Direct type variable injection must fail with a controlled exception");
+  }
+
+  @Test
+  void genericArrayInjectionFailsWithControlledException() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(GenericArrayConsumer.class),
+        "Generic array injection must fail with a controlled exception");
+  }
+
+  @Test
+  void genericArrayWrapperInjectionFailsWithControlledException() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(GenericArrayWrapperConsumer.class),
+        "Generic array wrapper injection must fail with a controlled exception");
+  }
+
+  @Test
+  void inheritedGenericFieldInjectionFailsWithControlledException() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(StringChildWithGenericField.class),
+        "Inherited generic field injection must fail with a controlled exception");
+  }
+
+  @Test
+  void typeVariableProviderReturnFailsWithControlledException() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(TypeVariableProviderFactory.class),
+        "Type variable @Provides return type must fail with a controlled exception");
+  }
+
+  @Test
+  void genericArrayProviderReturnFailsWithControlledException() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(GenericArrayProviderFactory.class),
+        "Generic array @Provides return type must fail with a controlled exception");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/providing/ProvidesSingletonRuntimeCloseTest.java
+++ b/src/test/java/io/github/suppierk/inject/providing/ProvidesSingletonRuntimeCloseTest.java
@@ -1,0 +1,39 @@
+package io.github.suppierk.inject.providing;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.suppierk.inject.Injector;
+import io.github.suppierk.inject.Provides;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+class ProvidesSingletonRuntimeCloseTest {
+  static class Resource implements AutoCloseable {
+    boolean closed;
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+  }
+
+  static class Factory {
+    private final Resource resource = new Resource();
+
+    @Provides
+    @Singleton
+    Object dependency() {
+      return resource;
+    }
+  }
+
+  @Test
+  void closesRuntimeAutoCloseableReturnedAsObject() {
+    final var injector = Injector.injector().add(Factory.class).build();
+    final var resource = (Resource) injector.get(Object.class);
+
+    injector.close();
+
+    assertTrue(resource.closed, "Runtime AutoCloseable singleton must be closed");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/providing/factories/FactoryProviderDuplicateTest.java
+++ b/src/test/java/io/github/suppierk/inject/providing/factories/FactoryProviderDuplicateTest.java
@@ -1,0 +1,41 @@
+package io.github.suppierk.inject.providing.factories;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.suppierk.inject.Injector;
+import io.github.suppierk.inject.Key;
+import io.github.suppierk.inject.Provides;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unused")
+class FactoryProviderDuplicateTest {
+  static class DuplicateFactory {
+    @Provides
+    Long first() {
+      return 1L;
+    }
+
+    @Provides
+    Long second() {
+      return 2L;
+    }
+  }
+
+  @Test
+  void duplicateProviderMethodReportsDuplicatedProvidedKey() {
+    final var builder = Injector.injector();
+
+    final var exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> builder.add(DuplicateFactory.class),
+            "Duplicate provider methods must fail");
+
+    assertEquals(
+        "Duplicate: " + new Key<>(Long.class, Set.of()),
+        exception.getMessage(),
+        "Duplicate provider error must report the duplicated provided key");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/providing/factories/FactoryProviderOverrideTest.java
+++ b/src/test/java/io/github/suppierk/inject/providing/factories/FactoryProviderOverrideTest.java
@@ -1,0 +1,115 @@
+package io.github.suppierk.inject.providing.factories;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.suppierk.inject.Injector;
+import io.github.suppierk.inject.Key;
+import io.github.suppierk.inject.Provides;
+import jakarta.inject.Named;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unused")
+class FactoryProviderOverrideTest {
+  static class ParentFactory {
+    @Provides
+    String dependency() {
+      return "parent";
+    }
+  }
+
+  static class ChildFactory extends ParentFactory {
+    @Override
+    @Provides
+    String dependency() {
+      return "child";
+    }
+  }
+
+  @Named("parent")
+  static class ParentQualifier {}
+
+  @Named("child")
+  static class ChildQualifier {}
+
+  @Named("staticParent")
+  static class StaticParentQualifier {}
+
+  @Named("staticChild")
+  static class StaticChildQualifier {}
+
+  static class ParentWithPrivateProvider {
+    @Provides
+    @Named("parent")
+    private String privateDependency() {
+      return "parent";
+    }
+  }
+
+  static class ChildWithSamePrivateProviderSignature extends ParentWithPrivateProvider {
+    @Provides
+    @Named("child")
+    String privateDependency() {
+      return "child";
+    }
+  }
+
+  static class ParentWithStaticProvider {
+    @Provides
+    @Named("staticParent")
+    static String staticDependency() {
+      return "parent";
+    }
+  }
+
+  static class ChildWithSameStaticProviderSignature extends ParentWithStaticProvider {
+    @Provides
+    @Named("staticChild")
+    static String staticDependency() {
+      return "child";
+    }
+  }
+
+  @Test
+  void overriddenProviderMethodUsesChildImplementation() {
+    final var injector =
+        assertDoesNotThrow(() -> Injector.injector().add(ChildFactory.class).build());
+
+    assertEquals("child", injector.get(String.class));
+  }
+
+  @Test
+  void privateParentProviderMethodIsNotOverriddenByChildMethodWithSameSignature() {
+    final var injector =
+        assertDoesNotThrow(
+            () -> Injector.injector().add(ChildWithSamePrivateProviderSignature.class).build());
+
+    assertEquals(
+        "parent",
+        injector.get(
+            new Key<>(String.class, Set.of(ParentQualifier.class.getAnnotation(Named.class)))));
+    assertEquals(
+        "child",
+        injector.get(
+            new Key<>(String.class, Set.of(ChildQualifier.class.getAnnotation(Named.class)))));
+  }
+
+  @Test
+  void staticParentProviderMethodIsNotOverriddenByChildMethodWithSameSignature() {
+    final var injector =
+        assertDoesNotThrow(
+            () -> Injector.injector().add(ChildWithSameStaticProviderSignature.class).build());
+
+    assertEquals(
+        "parent",
+        injector.get(
+            new Key<>(
+                String.class, Set.of(StaticParentQualifier.class.getAnnotation(Named.class)))));
+    assertEquals(
+        "child",
+        injector.get(
+            new Key<>(
+                String.class, Set.of(StaticChildQualifier.class.getAnnotation(Named.class)))));
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/providing/factories/FactoryProviderQualifiedReturnTest.java
+++ b/src/test/java/io/github/suppierk/inject/providing/factories/FactoryProviderQualifiedReturnTest.java
@@ -1,0 +1,49 @@
+package io.github.suppierk.inject.providing.factories;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import io.github.suppierk.inject.Injector;
+import io.github.suppierk.inject.Provides;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unused")
+class FactoryProviderQualifiedReturnTest {
+  @Named("service")
+  static class Service {}
+
+  static class Factory {
+    @Provides
+    Service service() {
+      return new Service();
+    }
+  }
+
+  static class Consumer {
+    private final Service service;
+
+    @Inject
+    Consumer(@Named("service") Service service) {
+      this.service = service;
+    }
+  }
+
+  @Test
+  void providerMethodReturningQualifiedClassUsesClassQualifierForLookup() {
+    final var injector = Injector.injector().add(Factory.class).build();
+
+    assertDoesNotThrow(
+        () -> injector.get(Service.class),
+        "Provider methods returning a qualified class must be retrievable by that class");
+  }
+
+  @Test
+  void providerMethodReturningQualifiedClassUsesClassQualifierForInjection() {
+    final var injector = Injector.injector().add(Factory.class, Consumer.class).build();
+
+    assertDoesNotThrow(
+        () -> injector.get(Consumer.class),
+        "Provider methods returning a qualified class must satisfy matching injection points");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/providing/factories/FactoryProviderValidationTest.java
+++ b/src/test/java/io/github/suppierk/inject/providing/factories/FactoryProviderValidationTest.java
@@ -1,0 +1,67 @@
+package io.github.suppierk.inject.providing.factories;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.suppierk.inject.Injector;
+import io.github.suppierk.inject.Provides;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unused")
+class FactoryProviderValidationTest {
+  static class VoidFactory {
+    @Provides
+    void dependency() {
+      // Intentionally empty
+    }
+  }
+
+  static class NullFactory {
+    @Provides
+    String dependency() {
+      return null;
+    }
+  }
+
+  static class SelfProvidedDependency {}
+
+  static class FactoryDependingOnOwnProvidedDependency {
+    @Inject
+    FactoryDependingOnOwnProvidedDependency(SelfProvidedDependency dependency) {}
+
+    @Provides
+    SelfProvidedDependency dependency() {
+      return new SelfProvidedDependency();
+    }
+  }
+
+  @Test
+  void voidProviderMethodFailsDuringRegistration() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(VoidFactory.class),
+        "Void @Provides methods must fail during registration");
+  }
+
+  @Test
+  void nonSingletonProviderMethodReturningNullFailsDuringRetrieval() {
+    final var injector = Injector.injector().add(NullFactory.class).build();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> injector.get(String.class),
+        "Non-singleton @Provides methods must not return null dependencies");
+  }
+
+  @Test
+  void factoryDependingOnOwnProvidedDependencyFailsAsCycle() {
+    final var builder = Injector.injector();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.add(FactoryDependingOnOwnProvidedDependency.class),
+        "Factory constructors must not depend on dependencies provided by the same factory");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/query/AnnotationPredicateTest.java
+++ b/src/test/java/io/github/suppierk/inject/query/AnnotationPredicateTest.java
@@ -121,6 +121,14 @@ class AnnotationPredicateTest {
     }
 
     @Test
+    void doesNotAcceptNullClassInMembersPredicateConstructor() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new AnnotationPredicate.AnnotationMembersPredicate<>(null),
+          "Annotation members predicate must not accept null class");
+    }
+
+    @Test
     void doesNotAcceptNullMemberValues() {
       final var builder = AnnotationPredicate.annotationPredicate().match(Named.class);
 

--- a/src/test/java/io/github/suppierk/inject/query/KeyAnnotationsPredicateAllMatchTest.java
+++ b/src/test/java/io/github/suppierk/inject/query/KeyAnnotationsPredicateAllMatchTest.java
@@ -1,0 +1,39 @@
+package io.github.suppierk.inject.query;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.suppierk.inject.Key;
+import io.github.suppierk.mocks.CustomQualifier;
+import jakarta.inject.Named;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+@Named("name")
+@CustomQualifier
+class KeyAnnotationsPredicateAllMatchTest {
+  @Test
+  void allMatchRequiresEveryQueryToMatchAtLeastOneAnnotation() {
+    final var customOnlyKey =
+        new Key<>(String.class, Set.of(getClass().getAnnotation(CustomQualifier.class)));
+    final var bothAnnotationsKey =
+        new Key<>(
+            String.class,
+            Set.of(
+                getClass().getAnnotation(CustomQualifier.class),
+                getClass().getAnnotation(Named.class)));
+    final var predicate =
+        KeyAnnotationsPredicate.keyAnnotationPredicate()
+            .allMatch()
+            .having(annotation -> annotation.match(CustomQualifier.class))
+            .having(annotation -> annotation.match(Named.class))
+            .build();
+
+    assertFalse(
+        predicate.test(customOnlyKey),
+        "allMatch must fail when at least one annotation query has no match");
+    assertTrue(
+        predicate.test(bothAnnotationsKey),
+        "allMatch must pass when every annotation query has a match");
+  }
+}

--- a/src/test/java/io/github/suppierk/inject/query/KeyAnnotationsPredicateTest.java
+++ b/src/test/java/io/github/suppierk/inject/query/KeyAnnotationsPredicateTest.java
@@ -234,6 +234,10 @@ class KeyAnnotationsPredicateTest {
                       null));
       assertThrows(
           IllegalArgumentException.class, () -> builder.having((AnnotationPredicate<?>) null));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> builder.having(annotationPredicate -> null),
+          "Annotation query modifier must not return null");
     }
   }
 }


### PR DESCRIPTION
## Summary                                                                                                          
                                                                                                                       
   - Add JSpecify/NullAway null-safety coverage and adjust public null contracts.                                      
   - Fix dependency graph correctness corner cases and improve validation diagnostics.                                 
   - Add post-construction adjuster API for injector-created classes.                                                  
   - Add captive dependency validation to reject singleton direct dependencies on non-singletons.                      
   - Make YAML/debug output deterministic.                                                                             
   - Improve topological sorting and key hash performance.                                                             
   - Add JMH benchmarks for chain, singleton-chain, and provider-method graph scenarios.                               
   - Address Sonar/Javadoc/test cleanup from the null-safety changes.                                                  
                                                                                                                       
   ## Notable behavior changes                                                                                         
                                                                                                                       
   - `@Singleton` bindings now fail build-time validation if they directly depend on non-singleton bindings.           
   - `Provider<T>` / `Supplier<T>` dependencies are exempt from captive dependency validation.                         
   - Adjusters run after constructor and field injection:                                                              
     - non-singletons: every creation                                                                                  
     - singletons: once                                                                                                
                                                                                                                       
   ## Validation                                                                                                       
                                                                                                                       
   - Gradle build and tests were run locally.                                                                          
   - Spotless was checked with isolated Gradle user home where needed.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
